### PR TITLE
docs(README): removing nb of downloads shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Dependency Status](https://david-dm.org/swimlane/ngx-datatable.svg)](https://david-dm.org/swimlane/ngx-datatable) 
 [![devDependency Status](https://david-dm.org/swimlane/ngx-datatable/dev-status.svg)](https://david-dm.org/swimlane/ngx-datatable#info=devDependencies) 
 [![npm version](https://badge.fury.io/js/%40swimlane%2Fngx-datatable.svg)](https://badge.fury.io/js/%40swimlane%2Fngx-datatable)
-[![npm downloads](https://img.shields.io/npm/dm/@swimlane/ngx-datatable.svg)](https://npmjs.org/@swimlane/ngx-datatable)
 
 `ngx-datatable` is a Angular2 component for presenting large and complex data.  It has all the features you would expect from any other table but in a light package with _no external dependencies_. The table was designed to be extremely flexible and light; it doesn't make any assumptions about your data or how you: filter, sort or page it.
 


### PR DESCRIPTION
The npm stats don't work on scoped modules (@.../...), I'm removing the npm number of downloads since it shows 0 now (even if that's not really 0).
