### PR TITLE
fixes "TypeError: Cannot read property 'setOffset' of undefined"

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -245,6 +245,10 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    * @memberOf DataTableBodyComponent
    */
   updateOffsetY(offset?: number): void {
+    // scroller is missing on empty table
+    if(!this.scroller) {
+        return;
+    }
     if(this.scrollbarV && offset) {
       // First get the row Index that we need to move to.
       const rowIndex = this.pageSize * offset;


### PR DESCRIPTION
Error occurs trying to sort empty table.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)

```
TypeError: Cannot read property 'setOffset' of undefined
    at DataTableBodyComponent.updateOffsetY (index.js:1778)
    at DatatableComponent.onColumnSort (index.js:3462)
    at View_DatatableComponent1.handleEvent_0 (component.ngfactory.js:92)
    at View_DatatableComponent1.<anonymous> (core.umd.js:12774)
    at SafeSubscriber.schedulerFn [as _next] (core.umd.js:4116)
    at SafeSubscriber.__tryOrUnsub (Subscriber.js:223)
    at SafeSubscriber.next (Subscriber.js:172)
    at Subscriber._next (Subscriber.js:125)
    at Subscriber.next (Subscriber.js:89)
    at EventEmitter.Subject.next (Subject.js:55)
    at EventEmitter.emit (core.umd.js:4090)
    at DataTableHeaderComponent.onSort (index.js:4249)
    at View_DataTableHeaderComponent2.handleEvent_0 (component.ngfactory.js:131)
    at View_DataTableHeaderComponent2.<anonymous> (core.umd.js:12774)
    at SafeSubscriber.schedulerFn [as _next] (core.umd.js:4116)
```


**Does this PR introduce a breaking change?** (check one with "x")
- [x] No

