### PR TITLE
longpress class not cleaned up

### DIFF
--- a/src/directives/long-press.directive.ts
+++ b/src/directives/long-press.directive.ts
@@ -26,7 +26,7 @@ export class LongPressDirective {
   get press(): boolean { return this.pressing; }
 
   @HostBinding('class.longpress')
-  get isLongPress(): boolean { 
+  get isLongPress(): boolean {
     return this.isLongPressing;
   }
 
@@ -78,7 +78,10 @@ export class LongPressDirective {
     this.longPressEnd.emit(true);
   }
 
-  @HostListener('mouseup')
-  onMouseUp(): void { this.endPress(); }
-
+  @HostListener('document:mouseup')
+  onMouseUp(): void {
+    if (this.isLongPressing) {
+      this.endPress()
+    }
+  }
 }


### PR DESCRIPTION
also reduced mouseup events from DraggableDirective and general fixes.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
If you hold a column header to drag, the longpress class gets active. If you then move the cursor out of the element while holding the element and let go, the mousup event of the element does not get fired.

This holds the longpress class on the header element.

**What is the new behavior?**
The mousup handler gets called when there is a longpress active and the mousebutton is let go.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
I couldn't find an issue for this, and since opening an issue would be more work than the fix was I did not create one. But if of course I could open one if you'd like.