### PR TITLE
Removed document:mouseup because it caused change detection too often.

### DIFF
--- a/src/directives/draggable.directive.ts
+++ b/src/directives/draggable.directive.ts
@@ -37,8 +37,9 @@ export class DraggableDirective implements OnDestroy {
     }
   }
 
-  @HostListener('document:mouseup', ['$event'])
   onMouseup(event: MouseEvent): void {
+    if (!this.isDragging) return;
+
     this.isDragging = false;
     this.element.classList.remove('dragging');
 
@@ -59,7 +60,12 @@ export class DraggableDirective implements OnDestroy {
       this.isDragging = true;
 
       const mouseDownPos = { x: event.clientX, y: event.clientY };
+
+      let mouseup = Observable.fromEvent(document, 'mouseup')
+        .do((ev: MouseEvent) => this.onMouseup(ev));
+
       this.subscription = Observable.fromEvent(document, 'mousemove')
+        .takeUntil(mouseup)
         .subscribe((ev: MouseEvent) => this.move(ev, mouseDownPos));
 
       this.dragStart.emit({
@@ -71,7 +77,7 @@ export class DraggableDirective implements OnDestroy {
   }
 
   move(event: MouseEvent, mouseDownPos: {x: number, y: number }): void {
-    if (!this.dragging) return;
+    if (!this.isDragging) return;
 
     const x = event.clientX - mouseDownPos.x;
     const y = event.clientY - mouseDownPos.y;

--- a/src/directives/long-press.directive.ts
+++ b/src/directives/long-press.directive.ts
@@ -6,6 +6,7 @@ import {
   HostBinding,
   HostListener
 } from '@angular/core';
+import {Observable, Subscription} from "rxjs";
 
 @Directive({ selector: '[long-press]' })
 export class LongPressDirective {
@@ -22,18 +23,20 @@ export class LongPressDirective {
   mouseX: number = 0;
   mouseY: number = 0;
 
+  subscription: Subscription;
+
   @HostBinding('class.press')
   get press(): boolean { return this.pressing; }
 
   @HostBinding('class.longpress')
-  get isLongPress(): boolean { 
+  get isLongPress(): boolean {
     return this.isLongPressing;
   }
 
   @HostListener('mousedown', ['$event'])
   onMouseDown(event: MouseEvent): void {
     // don't do right/middle clicks
-    if(event.which !== 1) return;
+    if (event.which !== 1) return;
 
     this.mouseX = event.clientX;
     this.mouseY = event.clientY;
@@ -41,29 +44,38 @@ export class LongPressDirective {
     this.pressing = true;
     this.isLongPressing = false;
 
+    let mouseup = Observable.fromEvent(document, 'mouseup');
+    this.subscription = mouseup.subscribe((ev: MouseEvent) => this.onMouseup());
+
     this.timeout = setTimeout(() => {
       this.isLongPressing = true;
       this.longPress.emit(event);
+
+      this.subscription.add(
+        Observable.fromEvent(document, 'mousemove')
+          .takeUntil(mouseup)
+          .subscribe((mouseEvent: MouseEvent) => this.onMouseMove(mouseEvent))
+      );
+
       this.loop(event);
     }, this.duration);
 
     this.loop(event);
   }
 
-  @HostListener('mousemove', ['$event'])
   onMouseMove(event: MouseEvent): void {
-    if(this.pressing && !this.isLongPressing) {
+    if (this.pressing && !this.isLongPressing) {
       const xThres = Math.abs(event.clientX - this.mouseX) > 10;
       const yThres = Math.abs(event.clientY - this.mouseY) > 10;
 
-      if(xThres || yThres) {
+      if (xThres || yThres) {
         this.endPress();
       }
     }
   }
 
   loop(event: Event): void {
-    if(this.isLongPressing) {
+    if (this.isLongPressing) {
       this.timeout = setTimeout(() => {
         this.longPressing.emit(event);
         this.loop(event);
@@ -75,10 +87,13 @@ export class LongPressDirective {
     clearTimeout(this.timeout);
     this.isLongPressing = false;
     this.pressing = false;
+    this.subscription.unsubscribe();
+
     this.longPressEnd.emit(true);
   }
 
-  @HostListener('mouseup')
-  onMouseUp(): void { this.endPress(); }
+  onMouseup(): void {
+    this.endPress()
+  }
 
 }

--- a/src/directives/resizeable.directive.ts
+++ b/src/directives/resizeable.directive.ts
@@ -38,7 +38,6 @@ export class ResizeableDirective implements OnDestroy {
     }
   }
 
-  @HostListener('document:mouseup')
   onMouseup(): void {
     this.resizing = false;
 
@@ -58,7 +57,11 @@ export class ResizeableDirective implements OnDestroy {
       event.stopPropagation();
       this.resizing = true;
 
+      let mouseup = Observable.fromEvent(document, 'mouseup')
+        .do((ev: MouseEvent) => this.onMouseup());
+
       this.subscription = Observable.fromEvent(document, 'mousemove')
+        .takeUntil(mouseup)
         .subscribe((e: MouseEvent) => this.move(e, initialWidth, mouseDownScreenX));
     }
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
By hooking into NgZone I found out that the global mouseup listeners in the header directives caused full changedetection to run. The mousup handlers were safe by checking if the body should be executed, but the cd cycle without the OnPush caused some performance degredation.
This is noticable in animations.

Should also have a positive impact on #503 

**What is the new behavior?**
MouseUp listeners are now only added when the user clicked the header, and destroyed when the mouseup event is thrown.
This means the mouseup events on the document do not have a handler all the time, so zonejs does not kick of the changedetection when a mouseup event is thrown anywhere on the document.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
