### PR TITLE
fix: fix row width and styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@angular/platform-browser": "~2.4.5",
     "@angular/platform-browser-dynamic": "~2.4.5",
     "@angular/platform-server": "~2.4.5",
-    "@types/jasmine": "^2.5.41",
+    "@types/jasmine": "2.5.41",
     "@types/node": "^7.0.4",
     "angular2-template-loader": "^0.6.0",
     "autoprefixer": "^6.5.4",

--- a/src/components/body/body-row.component.ts
+++ b/src/components/body/body-row.component.ts
@@ -40,6 +40,7 @@ export class DataTableBodyRowComponent {
     return this._columns;
   }
 
+  @HostBinding('style.width.px')
   @Input() set innerWidth(val: number) {
     this._innerWidth = val;
     this.recalculateColumns();


### PR DESCRIPTION
This fixes an issue where changing the width of the table component after it is rendered the background of the table rows do not look cut off.

[You can see the bug in action here.](http://plnkr.co/edit/26L6dAYk1d7xHvvGAPTK?p=preview)

**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

You can see the issue here that if you init a table in a component with a certain width, and then change the width to a larger width, the striped background does not extend across the entire table.
Even changing the window size which re-calculates the table does not help, which means calling re-calculate would not solve the issue.

**What is the new behavior?**

The row width is always correct even if it is changed after the table is rendered so the background color extends the entire row.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No