### PR TITLE
Fix for release build where the operators are treeshaken away.

### DIFF
--- a/src/directives/draggable.directive.ts
+++ b/src/directives/draggable.directive.ts
@@ -4,6 +4,8 @@ import {
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 
+import "rxjs/add/operator/takeUntil"
+
 /**
  * Draggable Directive for Angular2
  *
@@ -61,12 +63,15 @@ export class DraggableDirective implements OnDestroy {
 
       const mouseDownPos = { x: event.clientX, y: event.clientY };
 
-      let mouseup = Observable.fromEvent(document, 'mouseup')
-        .do((ev: MouseEvent) => this.onMouseup(ev));
+      let mouseup = Observable.fromEvent(document, 'mouseup');
+      this.subscription = mouseup
+        .subscribe((ev: MouseEvent) => this.onMouseup(ev));
 
-      this.subscription = Observable.fromEvent(document, 'mousemove')
+      let mouseMoveSub = Observable.fromEvent(document, 'mousemove')
         .takeUntil(mouseup)
         .subscribe((ev: MouseEvent) => this.move(ev, mouseDownPos));
+
+      this.subscription.add(mouseMoveSub);
 
       this.dragStart.emit({
         event,

--- a/src/directives/long-press.directive.ts
+++ b/src/directives/long-press.directive.ts
@@ -6,7 +6,10 @@ import {
   HostBinding,
   HostListener
 } from '@angular/core';
-import {Observable, Subscription} from "rxjs";
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
+
+import "rxjs/add/operator/takeUntil"
 
 @Directive({ selector: '[long-press]' })
 export class LongPressDirective {

--- a/src/directives/resizeable.directive.ts
+++ b/src/directives/resizeable.directive.ts
@@ -4,6 +4,8 @@ import {
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 
+import "rxjs/add/operator/takeUntil";
+
 @Directive({
   selector: '[resizeable]',
   host: {
@@ -57,12 +59,15 @@ export class ResizeableDirective implements OnDestroy {
       event.stopPropagation();
       this.resizing = true;
 
-      let mouseup = Observable.fromEvent(document, 'mouseup')
-        .do((ev: MouseEvent) => this.onMouseup());
+      let mouseup = Observable.fromEvent(document, 'mouseup');
+      this.subscription = mouseup
+        .subscribe((ev: MouseEvent) => this.onMouseup());
 
-      this.subscription = Observable.fromEvent(document, 'mousemove')
+      let mouseMoveSub = Observable.fromEvent(document, 'mousemove')
         .takeUntil(mouseup)
         .subscribe((e: MouseEvent) => this.move(e, initialWidth, mouseDownScreenX));
+
+      this.subscription.add(mouseMoveSub);
     }
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When using the released build and clicking the Datatable headers, there are javascript errors saying the 'do'-operator is not a function on observables.

Was introduced with my previous performance change, sorry!

**What is the new behavior?**
There is no exception when a user clicks the header.

I've removed the 'do' operator, and added an import to the takeUntil operator to be sure release builds will have the right operators imported

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
