### PR TITLE
fix: fix row width and styles

### DIFF
--- a/src/components/body/body-row.component.ts
+++ b/src/components/body/body-row.component.ts
@@ -40,7 +40,6 @@ export class DataTableBodyRowComponent {
     return this._columns;
   }
 
-  @HostBinding('style.width.px')
   @Input() set innerWidth(val: number) {
     this._innerWidth = val;
     this.recalculateColumns();
@@ -67,6 +66,11 @@ export class DataTableBodyRowComponent {
   @HostBinding('class.datatable-row-odd')
   get isOddRow(): boolean {
     return this.row.$$index % 2 !== 0;
+  }
+
+  @HostBinding('style.width.px')
+  get columnsTotalWidths(): string {
+    return this.columnGroupWidths.total;
   }
 
   @Output() activate: EventEmitter<any> = new EventEmitter();


### PR DESCRIPTION
Fixes a bug where the horizontal scrollbar would show up when it was not needed.

This bug was caused by #510.

**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

* Go to the `Horz/Vert Scrolling` demo under basic
* Make sure the screen is big enough where it shouldn't need a horizontal scroll
* Use your mouse to start scrolling down and notice the horizontal scroll bar shows up incorrectly


**What is the new behavior?**

The correct width is now used to take into account the scroll bar width. The horizontal scroller should not show up unless actually needed now.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No