### PR TITLE
reseting page offset on input data change

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -102,8 +102,7 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
     }
 
     this._rows = val;
-    //reset page offset on input changes due to filtering or other reason
-    this.offset = 0;
+
     // recalculate sizes/etc
     this.recalculate();
   }

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -102,7 +102,8 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
     }
 
     this._rows = val;
-
+    //reset page offset on input changes due to filtering or other reason
+    this.offset = 0;
     // recalculate sizes/etc
     this.recalculate();
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behaviour?** (You can also link to an open issue here)
Suppose my current `offset` is 10, `limit` is 10 and I have 100 rows to display. Now when I filter data based on some search or something I am left with 10 or 15 rows. The `total` count in footer is updated as expected but all rows are disappeared as the `offset` is not being reset.
issue: https://github.com/swimlane/ngx-datatable/issues/515

**What is the new behaviour?**
Reset offset to zero(page 1) whenever `rows` input is changed.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
One other approach can be checking if current offset have data to display and then reset offset accordingly.
Basically something like:
```
recalculatePages(): void {
    this.pageSize = this.calcPageSize();
    this.rowCount = this.calcRowCount();
    // on input data set change switch to the starting page offset, if total rows are lesser than current offset * limit
    if(this.rowCount / this.pageSize < this.offset) { 
      this.offset = 0;
    }
  }
```
but I think the current PR implementation provides more consistent behaviour.