### PR TITLE
fix: empty span.datatable-header-cell-wrapper with headerTemplate #504

### DIFF
--- a/src/components/header/header-cell.component.ts
+++ b/src/components/header/header-cell.component.ts
@@ -18,10 +18,11 @@ import { nextSortDir } from '../../utils';
           (change)="select.emit(!allRowsSelected)" 
         />
       </label>
-      <span class="datatable-header-cell-wrapper">
+      <span 
+        *ngIf="!column.headerTemplate"
+        class="datatable-header-cell-wrapper">
         <span
           class="datatable-header-cell-label draggable"
-          *ngIf="!column.headerTemplate"
           (click)="onSort()"
           [innerHTML]="name">
         </span>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
#504 


**What is the new behavior?**
Empty `span.datatable-header-cell-wrapper` element will no longer be present when using headerTemplate.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

Since the span was not wrapping the headerTemplate, it wouldn't have been useful for CSS styling. So I suspect no one noticed it or used it in their layout. Also, it had no dimensions.

