### PR TITLE
Fix resize handle overlaped by label

### DIFF
--- a/src/components/datatable.component.scss
+++ b/src/components/datatable.component.scss
@@ -157,7 +157,7 @@
         top: 0;
         bottom: 0;
         width: 5px;
-        padding: 0 8px;
+        padding: 0 4px;
         visibility: hidden;
         cursor: ew-resize;
       }

--- a/src/directives/resizeable.directive.ts
+++ b/src/directives/resizeable.directive.ts
@@ -1,5 +1,5 @@
 import {
-  Directive, ElementRef, HostListener, Input, Output, EventEmitter, OnDestroy
+  Directive, ElementRef, HostListener, Input, Output, EventEmitter, OnDestroy, AfterViewInit
 } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
@@ -12,7 +12,7 @@ import "rxjs/add/operator/takeUntil";
     '[class.resizeable]': 'resizeEnabled'
   }
 })
-export class ResizeableDirective implements OnDestroy {
+export class ResizeableDirective implements OnDestroy, AfterViewInit {
 
   @Input() resizeEnabled: boolean = true;
   @Input() minWidth: number;
@@ -26,7 +26,9 @@ export class ResizeableDirective implements OnDestroy {
 
   constructor(element: ElementRef) {
     this.element = element.nativeElement;
+  }
 
+  ngAfterViewInit(): void {
     if (this.resizeEnabled) {
       const node = document.createElement('span');
       node.classList.add('resize-handle');


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/swimlane/ngx-datatable/issues/496


**What is the new behavior?**
The `.resize-handle` is positioned right after the content of the header, so that browsers properly lays it out over it - allowing the resizing to be usable in such cases.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: