### PR TITLE
Fix mouse subscriptions cleanup

### DIFF
--- a/src/directives/long-press.directive.ts
+++ b/src/directives/long-press.directive.ts
@@ -4,7 +4,8 @@ import {
   Output,
   EventEmitter,
   HostBinding,
-  HostListener
+  HostListener,
+  OnDestroy
 } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
@@ -12,7 +13,7 @@ import { Subscription } from 'rxjs/Subscription';
 import "rxjs/add/operator/takeUntil"
 
 @Directive({ selector: '[long-press]' })
-export class LongPressDirective {
+export class LongPressDirective implements OnDestroy {
 
   @Input() duration: number = 500;
 
@@ -90,14 +91,24 @@ export class LongPressDirective {
     clearTimeout(this.timeout);
     this.isLongPressing = false;
     this.pressing = false;
-    this.subscription.unsubscribe();
+    this._destroySubscription();
 
     this.longPressEnd.emit(true);
   }
 
-
   onMouseup(): void {
     this.endPress()
+  }
+
+  ngOnDestroy(): void {
+    if (this.subscription) {
+      this._destroySubscription();
+    }
+  }
+
+  private _destroySubscription() {
+    this.subscription.unsubscribe();
+    this.subscription = undefined;
   }
 
 }

--- a/src/directives/resizeable.directive.ts
+++ b/src/directives/resizeable.directive.ts
@@ -36,7 +36,7 @@ export class ResizeableDirective implements OnDestroy {
 
   ngOnDestroy(): void {
     if (this.subscription) {
-      this.subscription.unsubscribe();
+      this._destroySubscription();
     }
   }
 
@@ -44,7 +44,7 @@ export class ResizeableDirective implements OnDestroy {
     this.resizing = false;
 
     if (this.subscription && !this.subscription.closed) {
-      this.subscription.unsubscribe();
+      this._destroySubscription();
       this.resize.emit(this.element.clientWidth);
     }
   }
@@ -81,6 +81,11 @@ export class ResizeableDirective implements OnDestroy {
     if (overMinWidth && underMaxWidth) {
       this.element.style.width = `${newWidth}px`;
     }
+  }
+
+  private _destroySubscription() {
+    this.subscription.unsubscribe();
+    this.subscription = undefined;
   }
 
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Given https://github.com/swimlane/ngx-datatable/pull/506 I think it is a good idea to remove the reference to the `subscriptions` when it is not needed any more and avoid possible strange issues.
There is no bug or issue I can relate that as I have not searched for any.