### PR TITLE
Fix for orderable unsubscribing 

### DIFF
--- a/src/directives/orderable.directive.spec.ts
+++ b/src/directives/orderable.directive.spec.ts
@@ -1,8 +1,10 @@
-import { async, TestBed, ComponentFixture } from '@angular/core/testing';
-import { Component, DebugElement } from '@angular/core';
-import { By } from '@angular/platform-browser';
+import {async, ComponentFixture, TestBed} from "@angular/core/testing";
+import {Component, ElementRef} from "@angular/core";
+import {By} from "@angular/platform-browser";
 
-import { OrderableDirective } from '.';
+import {OrderableDirective} from ".";
+import {DraggableDirective} from "./draggable.directive";
+import {id} from "../utils/id";
 
 @Component({
   selector: 'test-fixture-component',
@@ -21,7 +23,7 @@ describe('OrderableDirective', () => {
   // provide our implementations or mocks to the dependency injector
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ 
+      declarations: [
         OrderableDirective,
         TestFixtureComponent
       ]
@@ -45,7 +47,7 @@ describe('OrderableDirective', () => {
 
   describe('fixture', () => {
     let directive: OrderableDirective;
-    
+
     beforeEach(() => {
       directive = fixture.debugElement
         .query(By.directive(OrderableDirective))
@@ -58,6 +60,70 @@ describe('OrderableDirective', () => {
 
     it('should have OrderableDirective directive', () => {
       expect(directive).toBeTruthy();
+    });
+
+   describe('when a draggable is removed', () => {
+
+      function checkAllSubscriptionsForActiveObservers() {
+        let subs = directive.draggables.map(d => {
+          expect(d.dragEnd.isStopped).toBe(false);
+          expect(d.dragStart.isStopped).toBe(false);
+
+          return {
+            dragStart: d.dragStart.observers,
+            dragEnd: d.dragEnd.observers
+          }
+        });
+
+        subs.forEach((sub) => {
+          expect(sub.dragStart.length).toBe(1);
+          expect(sub.dragEnd.length).toBe(1);
+
+        })
+      }
+
+      function newDraggable() {
+        const draggable = new DraggableDirective(<ElementRef>{});
+
+        // used for the KeyValueDiffer
+        draggable.dragModel = {
+          $$id: id()
+        };
+
+        return draggable;
+      }
+
+      let draggables;
+
+      beforeEach(() => {
+        draggables = [
+          newDraggable(),
+          newDraggable(),
+          newDraggable()
+        ];
+
+        directive.draggables.reset(draggables);
+
+        directive.updateSubscriptions();
+
+        checkAllSubscriptionsForActiveObservers();
+      });
+
+      it('then dragStart and dragEnd are unsubscribed from the removed draggable', () => {
+        let unsubbed = draggables.splice(0,1)[0];
+
+        expect(unsubbed.dragStart.isStopped).toBe(false);
+        expect(unsubbed.dragEnd.isStopped).toBe(false);
+
+        directive.draggables.reset(draggables);
+
+        directive.updateSubscriptions();
+
+        checkAllSubscriptionsForActiveObservers();
+
+        expect(unsubbed.dragStart.isStopped).toBe(true);
+        expect(unsubbed.dragEnd.isStopped).toBe(true);
+      });
     });
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
reproducable on https://swimlane.github.io/ngx-datatable/# 

When toggling the Name column to off and then clicking the 'Company' column, a stacktrace pops up in the console.
`
Error: object unsubscribed
    at t.h (polyfills.js:1651)
    at new t (polyfills.js:1616)
    at t.next (polyfills.js:1609)
...
`

**Problem**
The KeyValueDiffer is used with an Array, which means it will use the index of the array to check for diffs.
When the Name column is removed the column-array us spliced, so no gaps occure.

This will cause the differ to think that the actual removed column was on the last index, since it went from [0, 1, 2] to [0,1]. The Company column was on this index, so it unsubscribed from the dragStart and dragEnd event emitters of the Company column, instead of the Name column.

**Fix**
By transforming the QueryElement Array into a map with the column.$$id as key, the KeyValueDiffer uses the column.$$id to diff the objects.

**What is the new behavior?**
The Company column does not lose its subscription to the draggable directive.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
