### PR TITLE
Fixes #396 by using relative imports

### DIFF
--- a/src/utils/column-helper.ts
+++ b/src/utils/column-helper.ts
@@ -1,5 +1,6 @@
 import { DataTableColumnDirective } from '../components/columns';
-import { camelCase, deCamelCase, id } from '../utils';
+import { camelCase, deCamelCase } from './camel-case';
+import { id } from './id';
 
 /**
  * Sets the column defaults


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Contains a circular dependency that results in roll-up to fail with a cannot read property id of undefined exception on import of the id module from column-helper.

See #396 


**What is the new behavior?**
Works correctly with roll-up


**Does this PR introduce a breaking change?** (check one with "x")
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
