### PR TITLE
fix: server side pagination

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -102,8 +102,6 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
     }
 
     this._rows = val;
-    //reset page offset on input changes due to filtering or other reason
-    this.offset = 0;
     // recalculate sizes/etc
     this.recalculate();
   }


### PR DESCRIPTION
Do not set offset to 0 when rows are changed so that you can show data loaded from the server for the second page.
Reverts #516

**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When you reset the rows array with new data from the server, the page will always go back to 1.

**What is the new behavior?**

The second page will show loaded from the server


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
