### PR TITLE
Fix: Bug with filtering data & server side pagination

### DIFF
--- a/src/components/datatable.component.spec.ts
+++ b/src/components/datatable.component.spec.ts
@@ -13,6 +13,77 @@ describe('Datatable component', () => {
     TestBed.compileComponents();
   }));
 
+  describe('When data for rows change', () => {
+    it('should not alter offset if there is enough data to display in table', () => {
+      let fixture = TestBed.createComponent(DatatableComponent);
+      let initialRows = [
+        { id: 1 },
+        { id: 2 },
+        { id: 3 },
+        { id: 4 },
+        { id: 5 },
+        { id: 6 },
+        { id: 7 },
+      ];
+      let columns = [
+        {
+          prop: 'foo'
+        }
+      ];
+      fixture.componentInstance.rows = initialRows;
+      fixture.componentInstance.columns = columns;
+      fixture.componentInstance.limit = 1;
+
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.offset).toBe(0);
+
+      fixture.componentInstance.offset = 5;
+      fixture.componentInstance.rows = initialRows.filter((r) => r.id < 6);
+
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.offset).toBe(5);
+    });
+
+    it('should reduce offset to minimum number that can display table data', () => {
+      let fixture = TestBed.createComponent(DatatableComponent);
+      let initialRows = [
+        { id: 1 },
+        { id: 2 },
+        { id: 3 },
+        { id: 4 },
+        { id: 5 },
+        { id: 6 },
+        { id: 7 },
+      ];
+      let columns = [
+        {
+          prop: 'foo'
+        }
+      ];
+
+      fixture.componentInstance.rows = initialRows;
+      fixture.componentInstance.columns = columns;
+      fixture.componentInstance.limit = 1;
+
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.offset).toBe(0);
+
+      fixture.componentInstance.offset = 5;
+
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.offset).toBe(5);
+
+      fixture.componentInstance.rows = initialRows.filter((r) => r.id < 3);
+
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.offset).toBe(2);
+    });
+  });
   describe('When the column is sorted with a custom comparator', () => {
 
     it('should return a new array', () => {

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -790,8 +790,8 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
   recalculatePages(): void {
     this.pageSize = this.calcPageSize();
     this.rowCount = this.calcRowCount();
-    while(this.rowCount / this.pageSize < this.offset) { 
-      this.offset--;
+    if(this.rowCount / this.pageSize < this.offset) {
+      this.offset = Math.floor(this.rowCount / this.pageSize);
     }
   }
 

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -790,6 +790,9 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
   recalculatePages(): void {
     this.pageSize = this.calcPageSize();
     this.rowCount = this.calcRowCount();
+    while(this.rowCount / this.pageSize < this.offset) { 
+      this.offset--;
+    }
   }
 
   /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
issue https://github.com/swimlane/ngx-datatable/issues/515
associated issue from PR https://github.com/swimlane/ngx-datatable/pull/543


**What is the new behavior?**
If there is enough data to display, no change in `offset` is done. (cases: server side pagination or filtering)
If there are not enough rows to display, change `offset` to maximum value that can show table rows. (cases: filtering)

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No
