### PR TITLE
Template column toggle fix + column handling rework

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -2,17 +2,17 @@ import {
   Component, Input, Output, ElementRef, EventEmitter, ViewChild,
   HostListener, ContentChildren, OnInit, QueryList, AfterViewInit,
   HostBinding, ContentChild, TemplateRef, IterableDiffer,
-  DoCheck, KeyValueDiffers, ViewEncapsulation
+  DoCheck, KeyValueDiffers, ViewEncapsulation, SimpleChange
 } from '@angular/core';
 
 import {
   forceFillColumnWidths, adjustColumnWidths, sortRows, scrollbarWidth,
   setColumnDefaults, throttleable, translateTemplates
 } from '../utils';
-import { ColumnMode, SortType, SelectionType } from '../types';
-import { DataTableBodyComponent } from './body';
-import { DataTableColumnDirective } from './columns';
-import { DatatableRowDetailDirective } from './row-detail';
+import {ColumnMode, SortType, SelectionType} from '../types';
+import {DataTableBodyComponent} from './body';
+import {DataTableColumnDirective} from './columns';
+import {DatatableRowDetailDirective} from './row-detail';
 
 @Component({
   selector: 'ngx-datatable',
@@ -123,12 +123,7 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    * @memberOf DatatableComponent
    */
   @Input() set columns(val: any[]) {
-    if(val) {
-      setColumnDefaults(val);
-      this.recalculateColumns(val);
-    }
-
-    this._columns = val;
+    this._columns = val
   }
 
   /**
@@ -368,8 +363,8 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    * A boolean/function you can use to check whether you want
    * to select a particular row based on a criteria. Example:
    *
-   *    (selection) => { 
-   *      return selection !== 'Ethel Price'; 
+   *    (selection) => {
+   *      return selection !== 'Ethel Price';
    *    }
    *
    * @type {*}
@@ -586,15 +581,42 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
   set columnTemplates(val: QueryList<DataTableColumnDirective>) {
     this._columnTemplates = val;
 
+    this._columnTemplates.changes.subscribe((val) => {
+      this.updateColumnTemplate(val)
+    });
+  }
+
+  updateColumnTemplate(val) {
+    // only set this if results were brought back
     if (val) {
-      // only set this if results were brought back
       const arr = val.toArray();
 
       if (arr.length) {
-        // translate them to normal objects
-        this.columns = translateTemplates(arr);
+        let templates = translateTemplates(arr);
+        let columns = [];
+
+        if (this.columns) {
+          columns = this._addTemplates(templates);
+        } else {
+          // columns were set through template only
+          columns = setColumnDefaults(templates);
+        }
+
+        this.columns = this.recalculateColumns(columns);
       }
     }
+  }
+
+  _addTemplates(templates) {
+    return this.columns.map((c) => {
+      let templateColumn = templates
+        .find(col => col.name === c.name);
+
+      if (templateColumn) {
+        return Object.assign({}, c, templateColumn)
+      }
+      return c;
+    })
   }
 
   /**
@@ -701,6 +723,21 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
     }
   }
 
+  ngOnChanges(changes) {
+    if (changes.hasOwnProperty('columns')) {
+      let change: SimpleChange = changes['columns'];
+
+      if (change.currentValue) {
+        let columns = setColumnDefaults(change.currentValue, false);
+
+        columns = this.recalculateColumns(columns);
+
+        this._columns = columns;
+        this._columnTemplates && this._columnTemplates.notifyOnChanges();
+      }
+    }
+  }
+
   /**
    * Recalc's the sizes of the grid.
    *
@@ -716,7 +753,7 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    */
   recalculate(): void {
     this.recalculateDims();
-    this.recalculateColumns();
+    this.columns = this.recalculateColumns(this.columns);
   }
 
   /**
@@ -746,6 +783,7 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
                      allowBleed: boolean = this.scrollbarH): any[] {
 
     if (!columns) return;
+    columns = columns.map(c => Object.assign({}, c));
 
     let width = this.innerWidth;
     if (this.scrollbarV) {
@@ -914,8 +952,7 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
       return c;
     });
 
-    this.recalculateColumns(cols, idx);
-    this._columns = cols;
+    this.columns = this.recalculateColumns(cols, idx);
 
     this.resize.emit({
       column,

--- a/src/utils/column-helper.ts
+++ b/src/utils/column-helper.ts
@@ -4,13 +4,16 @@ import { id } from './id';
 
 /**
  * Sets the column defaults
- * 
+ *
  * @export
  * @param {any[]} columns
  * @returns
  */
-export function setColumnDefaults(columns: any[]) {
+export function setColumnDefaults(columns: any[], override = true) {
   if(!columns) return;
+  if(override) {
+    columns = columns.map(c => Object.assign({}, c));
+  }
 
   for(const column of columns) {
     if(!column.$$id) {
@@ -47,11 +50,13 @@ export function setColumnDefaults(columns: any[]) {
       column.width = 150;
     }
   }
+
+  return columns;
 }
 
 /**
  * Translates templates definitions to objects
- * 
+ *
  * @export
  * @param {DataTableColumnDirective[]} templates
  * @returns {any[]}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:
Reworked column dataflow to support onPush.

**What is the current behavior?** (You can also link to an open issue here)
It started with fixing issue #533 where templates were not reapplied when toggling any colum.

**What is the new behavior?**
The templates are reapplied when toggling any column.

**The Bigger issue** 
I could not fix the issue without reworking the way the columns are set. 
Updating the templates called the setter of the columns, and weird things were happening.

There were many internal changes to the objects inside the columns array, which meant Angular can't detect all the changes properly and call the right handlers or hooks.
This can be seen in the demo page, where internal changes 'leaks' out to the column objects set by the developer.
If you put in a simple column, like `{ name: "Name" }`, you'll see that it has more properties when the datatable has processed it internally.

**The Bigger fix** 
I decouple the column objects in every function that changes it, so the original inputted columns remain the same.
By also handling the changes to the columns in the ngOnChange lifycyle hook, Angular has it easier to update the component tree.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No
- [x] Maybe

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

This fix works best when the columns are set to a new array everytime a change is done by the application using the datatable.
This means internally changing the columns array in the application won't update the table.

In my opinion, this is a better way to update the table. It follows the Immutable principle better and i believe this is the recommended way to update components in Angular.

But since there are issues opened where internally changing the columns array are expected to update the table, it would break for those use cases.

**Other information**: