### PR TITLE
fix: show first page after sorting

### DIFF
--- a/src/components/datatable.component.spec.ts
+++ b/src/components/datatable.component.spec.ts
@@ -5,7 +5,7 @@ describe('Datatable component', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ NgxDatatableModule ]
+      imports: [NgxDatatableModule]
     });
   });
 
@@ -18,9 +18,9 @@ describe('Datatable component', () => {
     it('should return a new array', () => {
       let fixture = TestBed.createComponent(DatatableComponent);
       let initialRows = [
-        { id: 1 },
-        { id: 2 },
-        { id: 3 }
+        {id: 1},
+        {id: 2},
+        {id: 3}
       ];
 
       let columns = [
@@ -41,16 +41,42 @@ describe('Datatable component', () => {
       expect(fixture.componentInstance.rows).toBe(initialRows);
 
       fixture.componentInstance.onColumnSort({
-        sorts: [{ prop: 'foo', dir: 'desc' }]
+        sorts: [{prop: 'foo', dir: 'desc'}]
       });
 
       fixture.componentInstance.sort
         .subscribe(() => {
-          console.log('sorted event');
         });
 
       expect(fixture.componentInstance.rows).not.toBe(initialRows);
     });
+  });
+
+  it('should set offset to 0 when sorting by a column', () => {
+    let fixture = TestBed.createComponent(DatatableComponent);
+    let initialRows = [
+      {id: 1},
+      {id: 2},
+      {id: 3}
+    ];
+
+    let columns = [
+      {
+        prop: 'id'
+      }
+    ];
+
+    fixture.componentInstance.rows = initialRows;
+    fixture.componentInstance.columns = columns;
+    fixture.componentInstance.offset = 1;
+
+    fixture.detectChanges();
+
+    fixture.componentInstance.onColumnSort({
+      sorts: [{prop: 'id', dir: 'desc'}]
+    });
+
+    expect(fixture.componentInstance.offset).toBe(0);
   });
 
 });

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -964,7 +964,9 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
     }
 
     this.sorts = sorts;
-    this.bodyComponent.updateOffsetY(0);
+    // Always go to first page when sorting to see the newly sorted data
+    this.offset = 0;
+    this.bodyComponent.updateOffsetY(this.offset);
     this.sort.emit(event);
   }
 


### PR DESCRIPTION
BREAKING CHANGES: For client side pagination with no vertical scroll, if you sort a column after navigating to any page but the first, you will be brought back to the first page rather than seeing the sorted results on the page you were currently on.

If you were using a vertical scroll, the sorting was already automatically pushing you back to the first page. This should be done for any sort event, so now regardless of your configuration, on sort you will be brought back to the first page.

Closes #270

**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**Using Vertical Scroll**

When sorting by a column, you are always brought back to the first page

**Client side sorting without vertical scroll**

When you sort you see the sorted results, on the page you are currently on. So if you are on page three and you sort by name alpha, you might be looking at the letter C, instead of going to page one and seeing letter A.

**Server side sorting without vertical scroll**

When you sort from a page which is not the first, you remain on that page and see no data.


**What is the new behavior?**

You always get brought back to the first page regardless of configuration when you are sorting.

**Does this PR introduce a breaking change?** (check one with "x")
- [X] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

Described in **Client side sorting without vertical scroll** above.