### PR TITLE
Fix: #557 documentation has the wrong path for the material theme.   …

### DIFF
--- a/docs/introduction/themes.md
+++ b/docs/introduction/themes.md
@@ -8,7 +8,7 @@ include that in your application `release/material.css` and add the CSS class `m
 This is a simple way to apply the style of the demo.
 ```scss
 @import '/node_modules/@swimlane/ngx-datatable/release/index.css';
-@import '/node_modules/@swimlane/ngx-datatable/release/material.css';
+@import '/node_modules/@swimlane/ngx-datatable/release/themes/material.css';
 @import '/node_modules/@swimlane/ngx-datatable/release/assets/icons.css';
 ```
 You can just add above to your `scss` file and then specify the class of your ngx-datatable to `<ngx-datatable class="material">`


### PR DESCRIPTION
…Corrected path to the material theme.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The documentation provides the wrong path to the themes css.

@import '/node_modules/@swimlane/ngx-datatable/release/material.css';


**What is the new behavior?**
 Corrected the path

@import '/node_modules/@swimlane/ngx-datatable/release/themes/material.css';

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
