### PR TITLE
Proposed fix for issue 559: Provide consistent page updates for client-side vertical scrolling

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -1,4 +1,4 @@
-  import {
+import {
   Component, Output, EventEmitter, Input, HostBinding, ViewChild, OnInit, OnDestroy
 } from '@angular/core';
 import { translateXY, columnsByPin, columnGroupWidths, RowHeightCache } from '../../utils';

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -1,4 +1,4 @@
-import {
+  import {
   Component, Output, EventEmitter, Input, HostBinding, ViewChild, OnInit, OnDestroy
 } from '@angular/core';
 import { translateXY, columnsByPin, columnGroupWidths, RowHeightCache } from '../../utils';
@@ -298,7 +298,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     let offset = this.indexes.first / this.pageSize;
 
     if(direction === 'up') {
-      offset = Math.floor(offset);
+      offset = Math.ceil(offset);
     } else if(direction === 'down') {
       offset = Math.ceil(offset);
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The active page is updated automatically when when client-side page updates and client-side vertical scrolling are enabled. The active page reaches an inconsistent state when scrolling up and down across page divides. This can be seen on the ngx-datatable demo page:

1. Go to http://swimlane.github.io/ngx-datatable/
2. Click "Sorting > Client-side" in the left navigation
3. Scroll down until "Netur" is barely visible. The active page is page 2.
4. Scroll up slightly. The active page is page 3.
5. Scroll back down slightly. The active page is page 2.

The active page should not increase from page 2 to page 3 when scrolling up. The active page should not decrease when scrolling down.

**What is the new behavior?**
The active page updates are consistent for scrolling up and scrolling down.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
