### PR TITLE
Datatable items don't return to original order when columns return to 'unsorted' state.

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -298,7 +298,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     let offset = this.indexes.first / this.pageSize;
 
     if(direction === 'up') {
-      offset = Math.ceil(offset);
+      offset = Math.floor(offset);
     } else if(direction === 'down') {
       offset = Math.ceil(offset);
     }

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -96,8 +96,10 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    * @memberOf DatatableComponent
    */
   @Input() set rows(val: any) {
-    // auto sort on new updates
     if (!this.externalSorting) {
+      // store original rows (so we can return to the default sort)
+      this._origRows = val;
+      // auto sort on new updates
       val = sortRows(val, this.columns, this.sorts);
     }
 
@@ -651,6 +653,7 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
   _count: number = 0;
 
   _rows: any[];
+  _origRows: any[];
   _columns: any[];
   _columnTemplates: QueryList<DataTableColumnDirective>;
 
@@ -960,7 +963,12 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
     // the rows again on the 'push' detection...
     if (this.externalSorting === false) {
       // don't use normal setter so we don't resort
-      this._rows = sortRows(this.rows, this.columns, sorts);
+      if (!sorts || sorts.length === 0) {
+        // restore original (unsorted) rows
+        this._rows = this._origRows;
+      } else {
+        this._rows = sortRows(this.rows, this.columns, sorts);
+      }
     }
 
     this.sorts = sorts;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
1) Go to the demo page:
http://swimlane.github.io/ngx-datatable/#
2) Navigate to Sorting > Client-side in the left navigation
3) Note the original order of items on the datatable, e.g. "Johnson, Johnson" is shown first
4) Sort the datatable by the Company column, items are sorted ascending
5) Sort the datatable again by the Company column, items are sorted descending
6) Sort the datatable yet again by the Company column, Company column is back to unsorted state yet the order remains descending

**What is the new behavior?**
When returning to the unsorted state for all columns (step 6 above) the original order of items in the datatable is restored.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
