### PR TITLE
Disable row mutation

### DIFF
--- a/demo/basic/inline.ts
+++ b/demo/basic/inline.ts
@@ -25,14 +25,14 @@ import { Component } from '@angular/core';
           <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
             <span
               title="Double click to edit"
-              (dblclick)="editing[row.$$index + '-name'] = true"
-              *ngIf="!editing[row.$$index + '-name']">
+              (dblclick)="editing[row.rowIndex + '-name'] = true"
+              *ngIf="!editing[row.rowIndex + '-name']">
               {{value}}
             </span>
             <input
               autofocus
               (blur)="updateValue($event, 'name', value, row)"
-              *ngIf="editing[row.$$index + '-name']"
+              *ngIf="editing[row.rowIndex + '-name']"
               type="text"
               [value]="value"
             />
@@ -42,12 +42,12 @@ import { Component } from '@angular/core';
           <ng-template ngx-datatable-cell-template let-row="row" let-value="value">
              <span
               title="Double click to edit"
-              (dblclick)="editing[row.$$index + '-gender'] = true"
-              *ngIf="!editing[row.$$index + '-gender']">
+              (dblclick)="editing[row.rowIndex + '-gender'] = true"
+              *ngIf="!editing[row.rowIndex + '-gender']">
               {{value}}
             </span>
             <select
-              *ngIf="editing[row.$$index + '-gender']"
+              *ngIf="editing[row.rowIndex + '-gender']"
               (change)="updateValue($event, 'gender', value, row)"
               [value]="value">
               <option value="male">Male</option>
@@ -87,8 +87,8 @@ export class InlineEditComponent {
   }
 
   updateValue(event, cell, cellValue, row) {
-    this.editing[row.$$index + '-' + cell] = false;
-    this.rows[row.$$index][cell] = event.target.value;
+    this.editing[row.rowIndex + '-' + cell] = false;
+    this.rows[row.rowIndex][cell] = event.target.value;
   }
 
 }

--- a/demo/basic/row-detail.ts
+++ b/demo/basic/row-detail.ts
@@ -1,4 +1,5 @@
 import { Component, ViewEncapsulation, ViewChild } from '@angular/core';
+import { RowMeta } from "../../src/types/row-meta";
 
 @Component({
   selector: 'row-details-demo',
@@ -31,7 +32,7 @@ import { Component, ViewEncapsulation, ViewChild } from '@angular/core';
           <ng-template let-row="row" ngx-datatable-row-detail-template>
             <div style="padding-left:35px;">
               <div><strong>Address</strong></div>
-              <div>{{row.address.city}}, {{row.address.state}}</div>
+              <div>{{row.row.address.city}}, {{row.row.address.state}}</div>
             </div>
           </ng-template>
         </ngx-datatable-row-detail>
@@ -46,8 +47,8 @@ import { Component, ViewEncapsulation, ViewChild } from '@angular/core';
           <ng-template let-row="row" ngx-datatable-cell-template>
             <a
               href="#"
-              [class.icon-right]="!row.$$expanded"
-              [class.icon-down]="row.$$expanded"
+              [class.icon-right]="!row.expanded"
+              [class.icon-down]="row.expanded"
               title="Expand/Collapse Row"
               (click)="toggleExpandRow(row)">
             </a>
@@ -55,12 +56,12 @@ import { Component, ViewEncapsulation, ViewChild } from '@angular/core';
         </ngx-datatable-column>
         <ngx-datatable-column name="Index" width="80">
           <ng-template let-row="row" ngx-datatable-cell-template>
-            <strong>{{row.$$index}}</strong>
+            <strong>{{row.rowIndex}}</strong>
           </ng-template>
         </ngx-datatable-column>
         <ngx-datatable-column name="Exapanded" width="80">
           <ng-template let-row="row" ngx-datatable-cell-template>
-            <strong>{{row.$$expanded === 1}}</strong>
+            <strong>{{row.rowIndex === 1}}</strong>
           </ng-template>
         </ngx-datatable-column>
         <ngx-datatable-column name="Name" width="200">
@@ -70,7 +71,7 @@ import { Component, ViewEncapsulation, ViewChild } from '@angular/core';
         </ngx-datatable-column>
         <ngx-datatable-column name="Gender" width="300">
           <ng-template let-row="row" let-value="value" ngx-datatable-cell-template>
-            <i [innerHTML]="row['name']"></i> and <i>{{value}}</i>
+            <i [innerHTML]="row.row['name']"></i> and <i>{{value}}</i>
           </ng-template>
         </ngx-datatable-column>
         <ngx-datatable-column name="Age" ></ngx-datatable-column>
@@ -112,7 +113,7 @@ export class RowDetailsComponent {
     req.send();
   }
 
-  toggleExpandRow(row) {
+  toggleExpandRow(row: RowMeta) {
     console.log('Toggled Expand Row!', row);
     this.table.rowDetail.toggleExpandRow(row);
   }

--- a/demo/basic/virtual.ts
+++ b/demo/basic/virtual.ts
@@ -29,7 +29,7 @@ import { Component } from '@angular/core';
         </ngx-datatable-column>
         <ngx-datatable-column name="Gender" width="300">
           <ng-template let-row="row" let-value="value" ngx-datatable-cell-template>
-            <i [innerHTML]="row['name']"></i> and <i>{{value}}</i>
+            <i [innerHTML]="row.row['name']"></i> and <i>{{value}}</i>
           </ng-template>
         </ngx-datatable-column>
         <ngx-datatable-column name="Age" width="80">

--- a/demo/sorting/sorting-default.ts
+++ b/demo/sorting/sorting-default.ts
@@ -24,13 +24,13 @@ import { Component, OnInit } from '@angular/core';
 
         <ngx-datatable-column name="Company">
           <ng-template let-row="row" ngx-datatable-cell-template>
-            {{row.company}}
+            {{row.row.company}}
           </ng-template>
         </ngx-datatable-column>
 
         <ngx-datatable-column name="Name">
           <ng-template let-row="row" ngx-datatable-cell-template>
-            {{row.name}}
+            {{row.row.name}}
           </ng-template>
         </ngx-datatable-column>
 

--- a/src/components/body/body-cell.component.ts
+++ b/src/components/body/body-cell.component.ts
@@ -4,7 +4,7 @@ import {
 } from '@angular/core';
 
 import { deepValueGetter, Keys } from '../../utils';
-import { SortDirection } from '../../types';
+import { SortDirection, RowMeta } from '../../types';
 
 @Component({
   selector: 'datatable-body-cell',
@@ -36,7 +36,7 @@ import { SortDirection } from '../../types';
 })
 export class DataTableBodyCellComponent {
 
-  @Input() row: any;
+  @Input() row: RowMeta;
   @Input() column: any;
   @Input() rowHeight: number;
   @Input() isSelected: boolean;
@@ -91,7 +91,7 @@ export class DataTableBodyCellComponent {
 
   get value(): any {
     if (!this.row || !this.column || !this.column.prop) return '';
-    const val = deepValueGetter(this.row, this.column.prop);
+    const val = deepValueGetter(this.row.row, this.column.prop);
     const userPipe: PipeTransform = this.column.pipe;
 
     if(userPipe) return userPipe.transform(val);

--- a/src/components/body/body-row-wrapper.component.ts
+++ b/src/components/body/body-row-wrapper.component.ts
@@ -1,6 +1,7 @@
 import { 
   Component, Input, Output, EventEmitter, HostListener 
 } from '@angular/core';
+import { RowMeta } from '../../types';
 
 @Component({
   selector: 'datatable-row-wrapper',
@@ -26,9 +27,9 @@ export class DataTableRowWrapperComponent {
   @Input() rowDetail: any;
   @Input() detailRowHeight: any;
   @Input() expanded: boolean = false;
-  @Input() row: any;
+  @Input() row: RowMeta;
   
-  @Output() rowContextmenu = new EventEmitter<{event: MouseEvent, row: any}>(false);
+  @Output() rowContextmenu = new EventEmitter<{event: MouseEvent, row: RowMeta}>(false);
 
   @HostListener('contextmenu', ['$event'])
   onContextmenu($event: MouseEvent): void {

--- a/src/components/body/body-row.component.ts
+++ b/src/components/body/body-row.component.ts
@@ -7,6 +7,8 @@ import {
   translateXY, Keys, scrollbarWidth
 } from '../../utils';
 
+import { RowMeta } from '../../types';
+
 @Component({
   selector: 'datatable-body-row',
   template: `
@@ -47,7 +49,7 @@ export class DataTableBodyRowComponent {
   }
 
   @Input() rowClass: any;
-  @Input() row: any;
+  @Input() row: RowMeta;
   @Input() offsetX: number;
   @Input() isSelected: boolean;
 
@@ -55,11 +57,12 @@ export class DataTableBodyRowComponent {
   get cssClass() {
     let cls = 'datatable-body-row';
     if(this.isSelected) cls += ' active';
-    if(this.row.$$index % 2 !== 0) cls += ' datatable-row-odd';
-    if(this.row.$$index % 2 === 0) cls += ' datatable-row-even';
+    if(this.row.rowIndex % 2 !== 0) cls += ' datatable-row-odd';
+    if(this.row.rowIndex % 2 === 0) cls += ' datatable-row-even';
 
     if(this.rowClass) {
-      const res = this.rowClass(this.row);
+      // TODO: Breaking change - send RowMeta to the function so implementation can get be smarter.
+      const res = this.rowClass(this.row.row);
       if(typeof res === 'string') {
         cls += res;
       } else if(typeof res === 'object') {

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -325,15 +325,14 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     const temp: RowMeta[] = [];
 
     while (rowIndex < rowLimit) {
-      const row = this._rows[rowIndex];
+      const rowMeta = this._rowsMeta[rowIndex]
+        || this._rows[rowIndex] && (this._rowsMeta[rowIndex] = { row: this._rows[rowIndex], rowIndex });
 
-      if(row) {
-        const rowMeta = this._rowsMeta[rowIndex] || (this._rowsMeta[rowIndex] = { row, rowIndex });
+      if(rowMeta) {
         rowMeta.rowIndex = rowIndex;
-        temp[idx] = rowMeta;
+        temp[idx++] = rowMeta;
       }
 
-      idx++;
       rowIndex++;
     }
 

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -316,12 +316,12 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    * @memberOf DataTableBodyComponent
    */
   updateRows(): void {
-    const { first, last } = this.indexes;
-    let rowIndex = first;
+    const rowLimit = Math.min(this.indexes.last, this.rowCount);
+    let rowIndex = this.indexes.first;
     let idx = 0;
     const temp: any[] = [];
 
-    while (rowIndex < last && rowIndex < this.rowCount) {
+    while (rowIndex < rowLimit) {
       const row = this.rows[rowIndex];
 
       if(row) {

--- a/src/components/body/selection.component.ts
+++ b/src/components/body/selection.component.ts
@@ -1,11 +1,11 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { Keys, selectRows, selectRowsBetween } from '../../utils';
-import { SelectionType } from '../../types';
+import { SelectionType, RowMeta } from '../../types';
 
 export interface Model {
   type: string;
   event: MouseEvent | KeyboardEvent;
-  row: any;
+  row: RowMeta;
   rowElement: any;
   cellElement: any;
   cellIndex: number;
@@ -19,7 +19,7 @@ export interface Model {
 })
 export class DataTableSelectionComponent {
 
-  @Input() rows: any[];
+  @Input() rows: RowMeta[];
   @Input() selected: any[];
   @Input() selectEnabled: boolean;
   @Input() selectionType: SelectionType;
@@ -31,7 +31,7 @@ export class DataTableSelectionComponent {
 
   prevIndex: number;
 
-  selectRow(event: KeyboardEvent | MouseEvent, index: number, row: any): void {
+  selectRow(event: KeyboardEvent | MouseEvent, index: number, row: RowMeta): void {
     if (!this.selectEnabled) return;
 
     const chkbox = this.selectionType === SelectionType.checkbox;
@@ -42,10 +42,10 @@ export class DataTableSelectionComponent {
     if (multi || chkbox || multiClick) {
       if (event.shiftKey) {
         selected = selectRowsBetween(
-          [], 
-          this.rows, 
-          index, 
-          this.prevIndex, 
+          [],
+          this.rows,
+          index,
+          this.prevIndex,
           this.getRowSelectedIdx.bind(this));
       } else if (event.ctrlKey || multiClick || chkbox) {
           selected = selectRows([...this.selected], row, this.getRowSelectedIdx.bind(this));
@@ -62,7 +62,7 @@ export class DataTableSelectionComponent {
 
     this.selected.splice(0, this.selected.length);
     this.selected.push(...selected);
-    
+
     this.prevIndex = index;
 
     this.select.emit({
@@ -73,7 +73,7 @@ export class DataTableSelectionComponent {
   onActivate(model: Model, index: number): void {
     const { type, event, row } = model;
     const chkbox = this.selectionType === SelectionType.checkbox;
-    const select = (!chkbox && (type === 'click' || type === 'dblclick')) || 
+    const select = (!chkbox && (type === 'click' || type === 'dblclick')) ||
       (chkbox && type === 'checkbox');
 
     if(select) {
@@ -148,14 +148,14 @@ export class DataTableSelectionComponent {
     if(nextCellElement) nextCellElement.focus();
   }
 
-  getRowSelected(row: any): boolean {
+  getRowSelected(row: RowMeta): boolean {
     return this.getRowSelectedIdx(row, this.selected) > -1;
   }
 
-  getRowSelectedIdx(row: any, selected: any[]): number {
+  getRowSelectedIdx(row: RowMeta, selected: any[]): number {
     if(!selected || !selected.length) return -1;
 
-    const rowId = this.rowIdentity(row);
+    const rowId = this.rowIdentity(row.row); // TODO: Breaking change - send RowMeta
     return selected.findIndex((r) => {
       const id = this.rowIdentity(r);
       return id === rowId;

--- a/src/components/row-detail/row-detail.directive.ts
+++ b/src/components/row-detail/row-detail.directive.ts
@@ -1,5 +1,6 @@
 import { Input, Output, EventEmitter, Directive, TemplateRef, ContentChild } from '@angular/core';
 import { DatatableRowDetailTemplateDirective } from './row-detail-template.directive';
+import { RowMeta } from '../../types/';
 
 @Directive({ selector: 'ngx-datatable-row-detail' })
 export class DatatableRowDetailDirective {
@@ -23,14 +24,14 @@ export class DatatableRowDetailDirective {
    * @type {EventEmitter<any>}
    * @memberOf DatatableComponent
    */
-  @Output() toggle: EventEmitter<any> = new EventEmitter();
+  @Output() toggle: EventEmitter<{type: 'row' | 'all', value: RowMeta | boolean}> = new EventEmitter();
 
   /**
    * Toggle the expansion of the row
    *
    * @param rowIndex
    */
-  toggleExpandRow(row: any): void {
+  toggleExpandRow(row: RowMeta): void {
     this.toggle.emit({
       type: 'row',
       value: row

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,4 @@ export * from './sort.type';
 export * from './sort-direction.type';
 export * from './selection.type';
 export * from './click.type';
+export * from './row-meta';

--- a/src/types/row-meta.ts
+++ b/src/types/row-meta.ts
@@ -1,0 +1,5 @@
+export interface RowMeta {
+  row: any;
+  rowIndex: number;
+  expanded?: number;
+}

--- a/src/utils/row-height-cache.ts
+++ b/src/utils/row-height-cache.ts
@@ -1,3 +1,5 @@
+import { RowMeta } from '../types';
+
 /**
  * This object contains the cache of the various row heights that are present inside
  * the data table.   Its based on Fenwick tree data structure that helps with
@@ -26,11 +28,11 @@ export class RowHeightCache {
   /**
    * Initialize the Fenwick tree with row Heights.
    *
-   * @param rows The array of rows which contain the expanded status.
+   * @param rowsMeta The array of RowMeta which contain the expanded status, not all indices are populated.
    * @param rowHeight The row height.
    * @param detailRowHeight The detail row height.
    */
-  initCache(rows: any[], rowHeight: number, detailRowHeight: number): void {
+  initCache(rowsMeta: RowMeta[], rowHeight: number, detailRowHeight: number): void {
     if (isNaN(rowHeight)) {
       throw new Error(`Row Height cache initialization failed. Please ensure that 'rowHeight' is a
         valid number value: (${rowHeight}) when 'scrollbarV' is enabled.`);
@@ -42,7 +44,7 @@ export class RowHeightCache {
         valid number value: (${detailRowHeight}) when 'scrollbarV' is enabled.`);
     }
 
-    const n = rows.length;
+    const n = rowsMeta.length;
     this.treeArray = new Array(n);
 
     for(let i = 0; i < n; ++i) {
@@ -54,7 +56,7 @@ export class RowHeightCache {
 
       // Add the detail row height to the already expanded rows.
       // This is useful for the table that goes through a filter or sort.
-      if (rows[i] && rows[i].$$expanded === 1) {
+      if (rowsMeta[i] && rowsMeta[i].expanded === 1) {
         currentRowHeight += detailRowHeight;
       }
 

--- a/src/utils/selection.ts
+++ b/src/utils/selection.ts
@@ -1,10 +1,12 @@
-export function selectRows(selected: any[], row: any, comparefn: any) {
+import { RowMeta } from '../types';
+
+export function selectRows(selected: any[], row: RowMeta, comparefn: any) {
   const selectedIndex = comparefn(row, selected);
 
   if(selectedIndex > -1) {
     selected.splice(selectedIndex, 1);
   } else {
-    selected.push(row);
+    selected.push(row.row);
   }
 
   return selected;
@@ -12,7 +14,7 @@ export function selectRows(selected: any[], row: any, comparefn: any) {
 
 export function selectRowsBetween(
   selected: any[], 
-  rows: any[], 
+  rows: RowMeta[],
   index: number, 
   prevIndex: number, 
   comparefn: any): any[] {
@@ -20,7 +22,7 @@ export function selectRowsBetween(
   const reverse = index < prevIndex;
 
   for(let i = 0; i < rows.length; i++) {
-    const row = rows[i];
+    const row = rows[i].row;
     const greater = i >= prevIndex && i <= index;
     const lesser = i <= prevIndex && i >= index;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
See #610

**What is the new behavior?**
See #610


**Does this PR introduce a breaking change?** (check one with "x")
- [X] Yes
- [ ] No

Rows are no longer mutated with `$$index` or `$$expanded`

Since not there, all custom templates that used these properties will no longer work.
To facilitate this, the `row` object sent to **all** templates is now of type `RowMeta` which is a wrapper around the original row object sent by the user.

```ts
export interface RowMeta {
  row: any;
  rowIndex: number;
  expanded?: number;
}
```

> NOTE: Future refactoring might add generic (`RowMeta<T>`) which leads to having `DatatableComponent<T>` at the top. This can wait till TS 2.3 is out and widely spread so we can assign a default to T and not bother our users with a breaking change.


Since the metadata is important for user logic, **all events** except **select** event now has `row` property as `RowMeta`. This means we can now easily extend this datatype to add more info as needed.

The select event send's the user supplied row instances.

The reason for this is that the `selected` **@Input** property excepts raw row instances from the user, if a user supplies this array the selector will have to traverse the whole array and find the index for each selected item, so I skipped that for the time being.
The drawback is that you can't get the selected indicies.

## Implementation:
Turns out that `WeakMap` is not suitable for this task.
The logic implemented throughout the library is using iteration over an array, this means that in a row array iteration in order to find a `RowMeta` there's going to Map lookup for every iteration.
Map is O(1) but still not as fast as an array index lookup, also a lot of browsers might use a polyfil that is far from O(1).

Instead, I kept the array logic and passed an array throughout the library which made the change easy to handle. The array is now of `RowMeta` instead of the user's raw rows.  
Now the only change is to access the `RowMeta#row` inside the receiving functions.

The array is lazy populated, it starts as an empty array with the length N (where N is the rows length) and get's populated by demand in `DataTableBodyComponent#updateRows()`.  
It fit's perfectly with `RowHeightCache` since we send `RowMeta` array, if the value is not in a specific index it's definitely not expanded.