### PR TITLE
fix(body-cell): set title on cell when not using cell template

### DIFF
--- a/src/components/body/body-cell.component.ts
+++ b/src/components/body/body-cell.component.ts
@@ -21,6 +21,7 @@ import { SortDirection } from '../../types';
       </label>
       <span
         *ngIf="!column.cellTemplate"
+        [title]="value"
         [innerHTML]="value">
       </span>
       <ng-template


### PR DESCRIPTION
This shows the full value on hover by using the HTML title attribute. Since the content of the cell can get cut off with ellipsis, it is needed for the user to see the entire content.

**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

You cannot see the entire content of a cell if it is too long and cut of with '...'

**What is the new behavior?**

You can now see the entire content by hovering over it. It will show up in the browser title hover.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

