### PR TITLE
Add the ability to deactivate the paging on scroll

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -214,6 +214,15 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
   @Input() externalPaging: boolean = false;
 
   /**
+   * If the table should use pagination on scroll
+   * otherwise it only uses the pagination in the footer
+   * 
+   * @type {boolean}
+   * @memberOf DatatableComponent
+   */
+  @Input() scrollPaging: boolean = true;
+
+  /**
    * If the table should use external sorting or
    * the built-in basic sorting.
    *
@@ -800,14 +809,16 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    * @memberOf DatatableComponent
    */
   onBodyPage({offset}: any): void {
-    this.offset = offset;
+    if (this.scrollPaging) {
+      this.offset = offset;
 
-    this.page.emit({
-      count: this.count,
-      pageSize: this.pageSize,
-      limit: this.limit,
-      offset: this.offset
-    });
+      this.page.emit({
+        count: this.count,
+        pageSize: this.pageSize,
+        limit: this.limit,
+        offset: this.offset
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When using the virtual scroll, the page is changing.


**What is the new behavior?**
Add an option `scrollPaging` that is defaulted to `true` to avoid any breaking changes.
If set to `false` the data table will ignore `page` event from the body, leaving the user to only use the footer's paging.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
I branched off of the 6.3.0 release commit as we are using 6.3.0. Do you plan to maintain 6.x.x versions?