### PR TITLE
fix(reorderable): fix reorderable=false and cursor css

### DIFF
--- a/demo/basic/basic-auto.component.ts
+++ b/demo/basic/basic-auto.component.ts
@@ -20,7 +20,8 @@ import { Component } from '@angular/core';
         [columnMode]="'force'"
         [headerHeight]="50"
         [footerHeight]="50"
-        [rowHeight]="'auto'">
+        [rowHeight]="'auto'"
+        [reorderable]="reorderable">
       </ngx-datatable>
     </div>
   `
@@ -29,6 +30,7 @@ export class BasicAutoComponent {
 
   rows = [];
   loadingIndicator: boolean = true;
+  reorderable: boolean = true;
 
   columns = [
     { prop: 'name' },

--- a/src/components/datatable.component.scss
+++ b/src/components/datatable.component.scss
@@ -140,7 +140,7 @@
         cursor: move;
       }
 
-      &.sortable {
+      .datatable-header-cell-wrapper {
         cursor: pointer;
       }
 
@@ -148,6 +148,7 @@
         line-height: 100%;
         vertical-align: middle;
         display: inline-block;
+        cursor: pointer;
       }
 
       .resize-handle{

--- a/src/components/header/header.component.ts
+++ b/src/components/header/header.component.ts
@@ -24,6 +24,7 @@ import { DataTableColumnDirective } from '../columns';
           (resize)="onColumnResized($event, column)"
           long-press
           [pressModel]="column"
+          [pressEnabled]="reorderable && column.draggable"
           (longPressStart)="onLongPressStart($event)"
           (longPressEnd)="onLongPressEnd($event)"
           draggable

--- a/src/directives/draggable.directive.ts
+++ b/src/directives/draggable.directive.ts
@@ -60,7 +60,10 @@ export class DraggableDirective implements OnDestroy, OnChanges {
   }
 
   onMousedown(event: MouseEvent): void {
-    if ((<HTMLElement>event.target).classList.contains('draggable')) {
+    // we only want to drag the inner header text
+    const isDragElm = (<HTMLElement>event.target).classList.contains('draggable');
+    
+    if(isDragElm && (this.dragX || this.dragY)) {
       event.preventDefault();
       this.isDragging = true;
 
@@ -93,15 +96,13 @@ export class DraggableDirective implements OnDestroy, OnChanges {
     if (this.dragX) this.element.style.left = `${x}px`;
     if (this.dragY) this.element.style.top = `${y}px`;
 
-    if (this.dragX || this.dragY) {
-      this.element.classList.add('dragging');
+    this.element.classList.add('dragging');
 
-      this.dragging.emit({
-        event,
-        element: this.element,
-        model: this.dragModel
-      });
-    }
+    this.dragging.emit({
+      event,
+      element: this.element,
+      model: this.dragModel
+    });
   }
 
   private _destroySubscription(): void {

--- a/src/directives/long-press.directive.ts
+++ b/src/directives/long-press.directive.ts
@@ -9,6 +9,7 @@ import 'rxjs/add/operator/takeUntil';
 @Directive({ selector: '[long-press]' })
 export class LongPressDirective implements OnDestroy {
 
+  @Input() pressEnabled: boolean = true;
   @Input() pressModel: any;
   @Input() duration: number = 500;
 
@@ -35,7 +36,7 @@ export class LongPressDirective implements OnDestroy {
   @HostListener('mousedown', [ '$event' ])
   onMouseDown(event: MouseEvent): void {
     // don't do right/middle clicks
-    if (event.which !== 1) return;
+    if(event.which !== 1 || !this.pressEnabled) return;
 
     // don't start drag if its on resize handle
     const target = (<HTMLElement>event.target);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Bugfix

**What is the current behavior?** (You can also link to an open issue here)
`[reorderable]="false"` not behaving correctly.
Entire header as `cursor:pointer;` CSS applied.

**What is the new behavior?**
`[reorderable]="false"` now behaving correctly.
Only label and sorting button have`cursor:pointer;` CSS applied.

**Does this PR introduce a breaking change?** (check one with "x")
No
