### PR TITLE
fix(*): only apply pointer to header text, fixes #682

### DIFF
--- a/src/components/datatable.component.scss
+++ b/src/components/datatable.component.scss
@@ -136,12 +136,12 @@
       position: relative;
       display: inline-block;
 
-      &.longpress {
-        cursor: move;
-      }
-
       .datatable-header-cell-wrapper {
         cursor: pointer;
+      }
+
+      &.longpress .datatable-header-cell-wrapper {
+        cursor: move;
       }
 
       .sort-btn {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
When long pressing on the header cell, entire cell has a `cursor: move` CSS applied, even though only the header text is reorder-able (see #682).


**What is the new behavior?**
With this change only the header text has the `cursor: move` CSS applied.


**Does this PR introduce a breaking change?** (check one with "x")
No

**Other information**:
The long press effect is still active for the entire cell, which can still be confusing.