### PR TITLE
Don't add column header title attribute when custom template provided, Fixes #643

### DIFF
--- a/src/components/header/header-cell.component.ts
+++ b/src/components/header/header-cell.component.ts
@@ -104,7 +104,7 @@ export class DataTableHeaderCellComponent {
   @HostBinding('attr.title')
   get name(): string {
     // guaranteed to have a value by setColumnDefaults() in column-helper.ts
-    return this.column.name;
+    return this.column.headerTemplate === undefined ? this.column.name : undefined;
   }
 
   @HostBinding('style.minWidth.px')


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When you use ng2 template tag for column header, TITLE attribute is being added automatically.


**What is the new behavior?**
When you use ng2 template tag for column header, TITLE attribute is not added.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
