### PR TITLE
check if column needs defaults set in BodyCellComponent.column setter

### DIFF
--- a/src/components/body/body-cell.component.ts
+++ b/src/components/body/body-cell.component.ts
@@ -6,6 +6,7 @@ import {
 import { Keys } from '../../utils';
 import { SortDirection } from '../../types';
 import { TableColumn } from '../../types/table-column.type';
+import { setSingleColumnDefaults } from '../../utils/column-helper';
 
 @Component({
   selector: 'datatable-body-cell',
@@ -39,7 +40,17 @@ import { TableColumn } from '../../types/table-column.type';
 export class DataTableBodyCellComponent implements OnDestroy {
 
   @Input() row: any;
-  @Input() column: TableColumn;
+
+  @Input() set column(column: TableColumn) {
+    this._column = column;
+    // check both $$id and $$valueGetter in case users try to manage $$id values
+    if (column && (column.$$id === undefined || column.$$valueGetter === undefined)) {
+      // setColumnDefaults was not called on this column due to how this component was constructed
+      setSingleColumnDefaults(column);
+    }
+  }
+  get column(): TableColumn { return this._column; }
+
   @Input() rowHeight: number;
   @Input() isSelected: boolean;
 
@@ -110,8 +121,9 @@ export class DataTableBodyCellComponent implements OnDestroy {
 
   sortDir: SortDirection;
   element: any;
-  _sorts: any[];
   isFocused: boolean = false;
+  private _column: TableColumn;
+  private _sorts: any[];
 
   constructor(element: ElementRef) {
     this.element = element.nativeElement;

--- a/src/utils/column-helper.ts
+++ b/src/utils/column-helper.ts
@@ -12,47 +12,55 @@ import { getterForProp } from './column-prop-getters';
  * @returns
  */
 export function setColumnDefaults(columns: TableColumn[]) {
-  if(!columns) return;
+  if (!columns) return;
 
-  for(const column of columns) {
-    if(!column.$$id) {
-      column.$$id = id();
-    }
+  for (const column of columns) {
+    setSingleColumnDefaults(column);
+  }
+}
 
-    // prop can be numeric; zero is valid not a missing prop
-    // translate name => prop
-    if(column.prop == null && column.name) {
-      column.prop = camelCase(column.name);
-    }
+/**
+ * Set the defaults of a single column.
+ * @param column
+ */
+export function setSingleColumnDefaults(column: TableColumn) {
+  if(!column.$$id) {
+    column.$$id = id();
+  }
 
-    if (!column.$$valueGetter) {
-      column.$$valueGetter = getterForProp(column.prop);
-    }
+  // prop can be numeric; zero is valid not a missing prop
+  // translate name => prop
+  if(column.prop == null && column.name) {
+    column.prop = camelCase(column.name);
+  }
 
-    // format props if no name passed
-    if(column.prop != null && !column.name) {
-      column.name = deCamelCase(String(column.prop));
-    }
+  if (!column.$$valueGetter) {
+    column.$$valueGetter = getterForProp(column.prop);
+  }
 
-    if(!column.hasOwnProperty('resizeable')) {
-      column.resizeable = true;
-    }
+  // format props if no name passed
+  if(column.prop != null && !column.name) {
+    column.name = deCamelCase(String(column.prop));
+  }
 
-    if(!column.hasOwnProperty('sortable')) {
-      column.sortable = true;
-    }
+  if(!column.hasOwnProperty('resizeable')) {
+    column.resizeable = true;
+  }
 
-    if(!column.hasOwnProperty('draggable')) {
-      column.draggable = true;
-    }
+  if(!column.hasOwnProperty('sortable')) {
+    column.sortable = true;
+  }
 
-    if(!column.hasOwnProperty('canAutoResize')) {
-      column.canAutoResize = true;
-    }
+  if(!column.hasOwnProperty('draggable')) {
+    column.draggable = true;
+  }
 
-    if(!column.hasOwnProperty('width')) {
-      column.width = 150;
-    }
+  if(!column.hasOwnProperty('canAutoResize')) {
+    column.canAutoResize = true;
+  }
+
+  if(!column.hasOwnProperty('width')) {
+    column.width = 150;
   }
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Some users are able to construct BodyCellComponent without `setColumnDefaults` being called on the column. This causes an error because $$valueGetter is undefined #683 

**What is the new behavior?**
BodyCellComponent column setter checks if defaults need to be set.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

May also fix #666 but I haven't reproduced that issue yet.