### PR TITLE
unit test deepValueGetter. fix #596 prop field name with dots.

### DIFF
--- a/src/utils/column-prop-getters.spec.ts
+++ b/src/utils/column-prop-getters.spec.ts
@@ -1,0 +1,53 @@
+import { deepValueGetter } from './column-prop-getters';
+
+describe('deepValueGetter', () => {
+
+  it('should get values one level deep', () => {
+    let data = {
+      a: {
+        value: 123
+      }
+    };
+    expect(deepValueGetter(data, 'a.value')).toEqual(123);
+  });
+
+  it('should get values two levels deep', () => {
+    let data = {
+      a: {
+        b: {
+          value: 'foo'
+        }
+      }
+    };
+    expect(deepValueGetter(data, 'a.b.value')).toEqual('foo');
+  });
+
+  it('should return empty string on missing nested field', () => {
+    let data = {
+      a: {}
+    };
+    expect(deepValueGetter(data, 'a.x.value')).toEqual('');
+  });
+
+  it('should return empty string on missing final field', () => {
+    let data = {
+      a: {}
+    };
+    expect(deepValueGetter(data, 'a.value')).toEqual('');
+  });
+
+  it('should return empty string on missing root field', () => {
+    let data = {
+      a: {}
+    };
+    expect(deepValueGetter(data, 'x.value')).toEqual('');
+  });
+
+  it('should check for root-level fields with dots in name', () => {
+    let data = {
+      "a.b.value": 5
+    };
+    expect(deepValueGetter(data, 'a.b.value')).toEqual(5);
+  });
+
+});

--- a/src/utils/column-prop-getters.ts
+++ b/src/utils/column-prop-getters.ts
@@ -8,7 +8,7 @@ export type ValueGetter = (obj: any, prop: TableColumnProp) => any;
  * Always returns the empty string ''
  * @returns {string}
  */
-export function emptyStringGetter() {
+export function emptyStringGetter(): string {
   return '';
 }
 
@@ -37,7 +37,7 @@ export function getterForProp(prop: TableColumnProp): ValueGetter {
  * @param index numeric index
  * @returns {any} or '' if invalid index
  */
-export function numericIndexGetter(row: any[], index: number) {
+export function numericIndexGetter(row: any[], index: number): any {
   // mimic behavior of deepValueGetter
   if (!row || index == null) return row;
 
@@ -53,7 +53,7 @@ export function numericIndexGetter(row: any[], index: number) {
  * @param fieldName field name string
  * @returns {any}
  */
-export function shallowValueGetter(obj: object, fieldName: string) {
+export function shallowValueGetter(obj: object, fieldName: string): any {
   if(!obj || !fieldName) return obj;
 
   const value = obj[fieldName];
@@ -66,10 +66,15 @@ export function shallowValueGetter(obj: object, fieldName: string) {
  * @param {object} obj
  * @param {string} path
  */
-export function deepValueGetter(obj: object, path: string) {
+export function deepValueGetter(obj: object, path: string): any {
   if(!obj || !path) return obj;
 
-  let current = obj;
+  // check if path matches a root-level field
+  // { "a.b.c": 123 }
+  let current = obj[path];
+  if (current !== undefined) return current;
+
+  current = obj;
   const split = path.split('.');
 
   if(split.length) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

prop: "a.b.c"
Doesn't first check for a field with dots actually in its name.
```
{
"a.b.c": 123
}
```


**What is the new behavior?**

If such a field exists, its value is returned before trying the deep value behavior.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Fixes #596 