### PR TITLE
Server pagination fix

### DIFF
--- a/demo/paging/mock-server-results-service.ts
+++ b/demo/paging/mock-server-results-service.ts
@@ -1,0 +1,43 @@
+import {Injectable} from "@angular/core";
+import {Observable} from "rxjs";
+import {PagedData} from "./model/paged-data";
+import {CorporateEmployee} from "./model/corporate-employee";
+import {Page} from "./model/page";
+var companyData = require('../../assets/data/company.json');
+
+/**
+ * A server used to mock a paged data result from a server
+ */
+@Injectable()
+export class MockServerResultsService {
+
+    /**
+     * A method that mocks a paged server response
+     * @param page The selected page
+     * @returns {any} An observable containing the employee data
+     */
+    public getResults(page: Page): Observable<PagedData<CorporateEmployee>> {
+        return Observable.of(companyData).map(data => this.getPagedData(page));
+    }
+
+    /**
+     * Package companyData into a PagedData object based on the selected Page
+     * @param page The page data used to get the selected data from companyData
+     * @returns {PagedData<CorporateEmployee>} An array of the selected data and page
+     */
+    private getPagedData(page: Page): PagedData<CorporateEmployee> {
+        let pagedData = new PagedData<CorporateEmployee>();
+        page.totalElements = companyData.length;
+        page.totalPages = page.totalElements / page.size;
+        let start = page.pageNumber * page.size;
+        let end = Math.min((start + page.size), page.totalElements);
+        for (let i = start; i < end; i++){
+            let jsonObj = companyData[i];
+            let employee = new CorporateEmployee(jsonObj.name, jsonObj.gender, jsonObj.company, jsonObj.age);
+            pagedData.data.push(employee);
+        }
+        pagedData.page = page;
+        return pagedData;
+    }
+
+}

--- a/demo/paging/model/corporate-employee.ts
+++ b/demo/paging/model/corporate-employee.ts
@@ -1,0 +1,16 @@
+/**
+ * A model for an individual corporate employee
+ */
+export class CorporateEmployee {
+    name: string;
+    gender: string;
+    company: string;
+    age: number;
+
+    constructor(name: string, gender: string, company: string, age: number){
+        this.name = name;
+        this.gender = gender;
+        this.company = company;
+        this.age = age;
+    }
+}

--- a/demo/paging/model/page.ts
+++ b/demo/paging/model/page.ts
@@ -1,0 +1,13 @@
+/**
+ * An object used to get page information from the server
+ */
+export class Page {
+    //The number of elements in the page
+    size: number = 0;
+    //The total number of elements
+    totalElements: number = 0;
+    //The total number of pages
+    totalPages: number = 0;
+    //The current page number
+    pageNumber: number = 0;
+}

--- a/demo/paging/model/paged-data.ts
+++ b/demo/paging/model/paged-data.ts
@@ -1,0 +1,9 @@
+import {Page} from "./page";
+
+/**
+ * An array of data with an associated page object used for paging
+ */
+export class PagedData<T> {
+    data = new Array<T>();
+    page = new Page();
+}

--- a/src/components/body/body.component.spec.ts
+++ b/src/components/body/body.component.spec.ts
@@ -48,7 +48,7 @@ describe('DataTableBodyComponent', () => {
   describe('Paging', () => {
 
     it('should have correct indexes for normal paging with rows > pageSize', () => {
-      component.externalPaging = false;
+      component.serverPaging = false;
       component.rows = [ {num: 1}, {num: 2}, {num: 3}, {num: 4}, {num: 5}, {num: 6}, {num: 7}, {num: 8}, {num: 9}, {num: 10} ];
       component.pageSize = 10;
       component.offset = 1;
@@ -59,7 +59,7 @@ describe('DataTableBodyComponent', () => {
     });
 
     it('should have correct indexes for normal paging with rows < pageSize', () => {
-      component.externalPaging = false;
+      component.serverPaging = false;
       component.rows = [ {num: 1}, {num: 2}, {num: 3}, {num: 4} ];
       component.pageSize = 5;
       component.offset = 1;
@@ -70,7 +70,7 @@ describe('DataTableBodyComponent', () => {
     });
 
     it('should have correct indexes for external paging with rows > pageSize', () => {
-      component.externalPaging = true;
+      component.serverPaging= true;
       component.rows = [ {num: 1}, {num: 2}, {num: 3}, {num: 4}, {num: 5}, {num: 6}, {num: 7}, {num: 8}, {num: 9}, {num: 10} ];
       component.pageSize = 10;
       component.offset = 1;
@@ -81,7 +81,7 @@ describe('DataTableBodyComponent', () => {
     });
 
     it('should have correct indexes for external paging with rows < pageSize', () => {
-      component.externalPaging = true;
+      component.serverPaging = true;
       component.rows = [ {num: 1}, {num: 2}, {num: 3}, {num: 4} ];
       component.pageSize = 5;
       component.offset = 1;

--- a/src/components/body/body.component.spec.ts
+++ b/src/components/body/body.component.spec.ts
@@ -48,7 +48,7 @@ describe('DataTableBodyComponent', () => {
   describe('Paging', () => {
 
     it('should have correct indexes for normal paging with rows > pageSize', () => {
-      component.serverPaging = false;
+      component.externalPaging = false;
       component.rows = [ {num: 1}, {num: 2}, {num: 3}, {num: 4}, {num: 5}, {num: 6}, {num: 7}, {num: 8}, {num: 9}, {num: 10} ];
       component.pageSize = 10;
       component.offset = 1;
@@ -59,7 +59,7 @@ describe('DataTableBodyComponent', () => {
     });
 
     it('should have correct indexes for normal paging with rows < pageSize', () => {
-      component.serverPaging = false;
+      component.externalPaging = false;
       component.rows = [ {num: 1}, {num: 2}, {num: 3}, {num: 4} ];
       component.pageSize = 5;
       component.offset = 1;
@@ -70,7 +70,7 @@ describe('DataTableBodyComponent', () => {
     });
 
     it('should have correct indexes for external paging with rows > pageSize', () => {
-      component.serverPaging= true;
+      component.externalPaging = true;
       component.rows = [ {num: 1}, {num: 2}, {num: 3}, {num: 4}, {num: 5}, {num: 6}, {num: 7}, {num: 8}, {num: 9}, {num: 10} ];
       component.pageSize = 10;
       component.offset = 1;
@@ -81,7 +81,7 @@ describe('DataTableBodyComponent', () => {
     });
 
     it('should have correct indexes for external paging with rows < pageSize', () => {
-      component.serverPaging = true;
+      component.externalPaging = true;
       component.rows = [ {num: 1}, {num: 2}, {num: 3}, {num: 4} ];
       component.pageSize = 5;
       component.offset = 1;

--- a/src/components/body/body.component.spec.ts
+++ b/src/components/body/body.component.spec.ts
@@ -43,4 +43,53 @@ describe('DataTableBodyComponent', () => {
       expect(component).toBeTruthy();
     });
   });
+
+
+  describe('Paging', () => {
+
+    it('should have correct indexes for normal paging with rows > pageSize', () => {
+      component.externalPaging = false;
+      component.rows = [ {num: 1}, {num: 2}, {num: 3}, {num: 4}, {num: 5}, {num: 6}, {num: 7}, {num: 8}, {num: 9}, {num: 10} ];
+      component.pageSize = 10;
+      component.offset = 1;
+      component.rowCount = 20;
+      let expectedIndexes = { first: 10, last: 20};
+      component.updateIndexes();
+      expect(component.indexes).toEqual(expectedIndexes);
+    });
+
+    it('should have correct indexes for normal paging with rows < pageSize', () => {
+      component.externalPaging = false;
+      component.rows = [ {num: 1}, {num: 2}, {num: 3}, {num: 4} ];
+      component.pageSize = 5;
+      component.offset = 1;
+      component.rowCount = 9;
+      let expectedIndexes = { first: 5, last: 9};
+      component.updateIndexes();
+      expect(component.indexes).toEqual(expectedIndexes);
+    });
+
+    it('should have correct indexes for external paging with rows > pageSize', () => {
+      component.externalPaging = true;
+      component.rows = [ {num: 1}, {num: 2}, {num: 3}, {num: 4}, {num: 5}, {num: 6}, {num: 7}, {num: 8}, {num: 9}, {num: 10} ];
+      component.pageSize = 10;
+      component.offset = 1;
+      component.rowCount = 20;
+      let expectedIndexes = { first: 0, last: 10};
+      component.updateIndexes();
+      expect(component.indexes).toEqual(expectedIndexes);
+    });
+
+    it('should have correct indexes for external paging with rows < pageSize', () => {
+      component.externalPaging = true;
+      component.rows = [ {num: 1}, {num: 2}, {num: 3}, {num: 4} ];
+      component.pageSize = 5;
+      component.offset = 1;
+      component.rowCount = 9;
+      let expectedIndexes = { first: 0, last: 5};
+      component.updateIndexes();
+      expect(component.indexes).toEqual(expectedIndexes);
+    });
+
+  });
 });

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -65,6 +65,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   @Input() scrollbarV: boolean;
   @Input() scrollbarH: boolean;
   @Input() loadingIndicator: boolean;
+  @Input() externalPaging: boolean;
   @Input() rowHeight: number;
   @Input() offsetX: number;
   @Input() emptyMessage: string;
@@ -457,7 +458,11 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
       first = this.rowHeightsCache.getRowIndex(this.offsetY);
       last = this.rowHeightsCache.getRowIndex(height + this.offsetY) + 1;
     } else {
-      first = Math.max(this.offset * this.pageSize, 0);
+      // The server is handling paging and will pass an array that begins with the
+      // element at a specified offset.  first should always be 0 with external paging.
+      if (!this.externalPaging) {
+        first = Math.max(this.offset * this.pageSize, 0);
+      }
       last = Math.min((first + this.pageSize), this.rowCount);
     }
 

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -65,7 +65,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   @Input() scrollbarV: boolean;
   @Input() scrollbarH: boolean;
   @Input() loadingIndicator: boolean;
-  @Input() externalPaging: boolean;
+  @Input() serverPaging: boolean;
   @Input() rowHeight: number;
   @Input() offsetX: number;
   @Input() emptyMessage: string;
@@ -460,7 +460,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     } else {
       // The server is handling paging and will pass an array that begins with the
       // element at a specified offset.  first should always be 0 with external paging.
-      if (!this.externalPaging) {
+      if (!this.serverPaging) {
         first = Math.max(this.offset * this.pageSize, 0);
       }
       last = Math.min((first + this.pageSize), this.rowCount);

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -65,7 +65,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   @Input() scrollbarV: boolean;
   @Input() scrollbarH: boolean;
   @Input() loadingIndicator: boolean;
-  @Input() serverPaging: boolean;
+  @Input() externalPaging: boolean;
   @Input() rowHeight: number;
   @Input() offsetX: number;
   @Input() emptyMessage: string;
@@ -460,7 +460,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     } else {
       // The server is handling paging and will pass an array that begins with the
       // element at a specified offset.  first should always be 0 with external paging.
-      if (!this.serverPaging) {
+      if (!this.externalPaging) {
         first = Math.max(this.offset * this.pageSize, 0);
       }
       last = Math.min((first + this.pageSize), this.rowCount);

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -46,7 +46,7 @@ import { DatatableFooterDirective } from './footer';
         [scrollbarV]="scrollbarV"
         [scrollbarH]="scrollbarH"
         [loadingIndicator]="loadingIndicator"
-        [externalPaging]="externalPaging"
+        [serverPaging]="serverPaging"
         [rowHeight]="rowHeight"
         [rowCount]="rowCount"
         [offset]="offset"
@@ -209,6 +209,7 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    */
   @Input() footerHeight: number = 0;
 
+
   /**
    * If the table should use external paging
    * otherwise its assumed that all data is preloaded.
@@ -216,7 +217,18 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    * @type {boolean}
    * @memberOf DatatableComponent
    */
-  @Input() externalPaging: boolean = false;
+  @Input() serverPaging: boolean = false;
+
+  /**
+   * If the table should use external paging
+   * otherwise its assumed that all data is preloaded.
+   *
+   * @type {boolean}
+   * @memberOf DatatableComponent
+   * @deprecated This has been replaced with serverPaging.  The serverPaging config flag calculates indexes differently
+   *             so that pagination can be handled by the server.
+   */
+  @Input() externalPaging: boolean = this.serverPaging;
 
   /**
    * If the table should use external sorting or

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -46,6 +46,7 @@ import { DatatableFooterDirective } from './footer';
         [scrollbarV]="scrollbarV"
         [scrollbarH]="scrollbarH"
         [loadingIndicator]="loadingIndicator"
+        [externalPaging]="externalPaging"
         [rowHeight]="rowHeight"
         [rowCount]="rowCount"
         [offset]="offset"

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -228,7 +228,7 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    * @deprecated This has been replaced with serverPaging.  The serverPaging config flag calculates indexes differently
    *             so that pagination can be handled by the server.
    */
-  @Input() externalPaging: boolean = this.serverPaging;
+  @Input() externalPaging: boolean = false;
 
   /**
    * If the table should use external sorting or
@@ -919,7 +919,7 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    * @memberOf DatatableComponent
    */
   calcRowCount(val: any[] = this.rows): number {
-    if (!this.externalPaging) {
+    if (!this.externalPaging && !this.serverPaging) {
       if (!val) return 0;
       return val.length;
     }

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -46,7 +46,7 @@ import { DatatableFooterDirective } from './footer';
         [scrollbarV]="scrollbarV"
         [scrollbarH]="scrollbarH"
         [loadingIndicator]="loadingIndicator"
-        [serverPaging]="serverPaging"
+        [externalPaging]="externalPaging"
         [rowHeight]="rowHeight"
         [rowCount]="rowCount"
         [offset]="offset"
@@ -209,24 +209,12 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    */
   @Input() footerHeight: number = 0;
 
-
   /**
    * If the table should use external paging
    * otherwise its assumed that all data is preloaded.
    *
    * @type {boolean}
    * @memberOf DatatableComponent
-   */
-  @Input() serverPaging: boolean = false;
-
-  /**
-   * If the table should use external paging
-   * otherwise its assumed that all data is preloaded.
-   *
-   * @type {boolean}
-   * @memberOf DatatableComponent
-   * @deprecated This has been replaced with serverPaging.  The serverPaging config flag calculates indexes differently
-   *             so that pagination can be handled by the server.
    */
   @Input() externalPaging: boolean = false;
 
@@ -919,7 +907,7 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    * @memberOf DatatableComponent
    */
   calcRowCount(val: any[] = this.rows): number {
-    if (!this.externalPaging && !this.serverPaging) {
+    if (!this.externalPaging) {
       if (!val) return 0;
       return val.length;
     }


### PR DESCRIPTION
This change addresses #138.  You can try it using `npm i @dcesiel/ngx-datatable`

TODO:
1. Add documentation for change.
2. Modify server paging demo for change.

**What kind of change does this PR introduce?** (check one with "x")
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently ngx-datatable calculates a non-zero first index in BodyComponent.updateIndexes() when server pagination is selected.  This becomes an issue when using standard pagination such as [spring-data pagination](http://ankushs92.github.io/tutorial/2016/05/03/pagination-with-spring-boot.html) where the first value in the results array will be the value at the specified offset in the request.


**What is the new behavior?**
Because the server is handles grabbing the page subset for us, the first index calculated by BodyComponent.updateIndexes() should always be 0 and the last should be 0 + pageSize.


**Does this PR introduce a breaking change?** (check one with "x")
- [ x ] Yes
- [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

The externalPaging config flag has been deprecated in favor of serverPaging which behaves the same way except for the index calculation change.

**Other information**:
