### PR TITLE
Fix #659 header checkbox when row selection is changed

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -663,6 +663,7 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
   get allRowsSelected(): boolean {
     return this.selected &&
       this.rows &&
+      this.rows.length !== 0 &&
       this.selected.length === this.rows.length;
   }
 

--- a/src/components/header/header-cell.component.ts
+++ b/src/components/header/header-cell.component.ts
@@ -14,7 +14,7 @@ import { nextSortDir } from '../../utils';
         class="datatable-checkbox">
         <input 
           type="checkbox"
-          [attr.checked]="allRowsSelected"
+          [checked]="allRowsSelected"
           (change)="select.emit(!allRowsSelected)" 
         />
       </label>

--- a/src/components/header/header.component.ts
+++ b/src/components/header/header.component.ts
@@ -39,6 +39,7 @@ import { DataTableColumnDirective } from '../columns';
           [selectionType]="selectionType"
           [sortAscendingIcon]="sortAscendingIcon"
           [sortDescendingIcon]="sortDescendingIcon"
+          [allRowsSelected]="allRowsSelected"
           (sort)="onSort($event)"
           (select)="select.emit($event)">
         </datatable-header-cell>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behaviour?** (You can also link to an open issue here)
Selecting all rows with the header checkbox works as expected, when you deselect a single checkbox in a row of the body the header checkbox isn't deselected. (related issue #659)


**What is the new behaviour?**
Deselecting a checkbox in the body also trigger the header checkbox.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information**:
The ``allRowsSelected`` input wasn't passed down to the child element. I've also made a change to the ``checked`` attribute as this wasn't properly triggered using ``attr.checked``. Furthermore I've added a length check on the rows to prevent the header checkbox from initially being checked.