### PR TITLE
Add server-side scrolling demo

### DIFF
--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -62,6 +62,7 @@ import { Location, LocationStrategy, HashLocationStrategy } from '@angular/commo
             <ul>
               <li><a href="#client-paging" (click)="state='client-paging'">Client-side</a></li>
               <li><a href="#server-paging" (click)="state='server-paging'">Server-side</a></li>
+              <li><a href="#server-scrolling" (click)="state='server-scrolling'">Scrolling server-side</a></li>
               <li><a href="#virtual-paging" (click)="state='virtual-paging'">Virual server-side</a></li>
             </ul>
           </li>
@@ -128,6 +129,7 @@ import { Location, LocationStrategy, HashLocationStrategy } from '@angular/commo
         <!-- Paging -->
         <client-paging-demo *ngIf="state === 'client-paging'"></client-paging-demo>
         <server-paging-demo *ngIf="state === 'server-paging'"></server-paging-demo>
+        <server-scrolling-demo *ngIf="state === 'server-scrolling'"></server-scrolling-demo>
         <virtual-paging-demo *ngIf="state === 'virtual-paging'"></virtual-paging-demo>
 
         <!-- Sorting -->

--- a/demo/module.ts
+++ b/demo/module.ts
@@ -26,6 +26,7 @@ import { FooterDemoComponent } from './basic/footer.component';
 // -- Paging
 import { ClientPagingComponent } from './paging/paging-client.component';
 import { ServerPagingComponent } from './paging/paging-server.component';
+import { ServerScrollingComponent } from './paging/scrolling-server.component';
 import { VirualPagingComponent } from './paging/paging-virtual.component';
 
 // -- Sorting
@@ -67,6 +68,7 @@ import { ColumnPinningComponent } from './columns/pinning.component';
     RowDetailsComponent,
     ClientPagingComponent,
     ServerPagingComponent,
+    ServerScrollingComponent,
     ClientSortingComponent,
     DefaultSortingComponent,
     ServerSortingComponent,

--- a/demo/paging/scrolling-server.component.ts
+++ b/demo/paging/scrolling-server.component.ts
@@ -1,0 +1,72 @@
+import { Component } from '@angular/core';
+import {MockServerResultsService} from "./mock-server-results-service";
+import {PagedData} from "./model/paged-data";
+import {CorporateEmployee} from "./model/corporate-employee";
+import {Page} from "./model/page";
+
+@Component({
+  selector: 'server-scrolling-demo',
+  providers: [
+      MockServerResultsService
+  ],
+  template: `
+    <div>
+      <h3>
+        Server-side Scrolling
+        <small>
+          <a href="https://github.com/swimlane/ngx-datatable/blob/master/demo/paging/server-scrolling.component.ts" target="_blank">
+            Source
+          </a>
+        </small>
+      </h3>
+      <ngx-datatable
+        class="material"
+        [rows]="rows"
+        [columns]="[{name:'Name'},{name:'Gender'},{name:'Company'}]"
+        [columnMode]="'force'"
+        [headerHeight]="50"
+        [footerHeight]="0"
+        [rowHeight]="50"
+        [scrollbarV]="true"
+        (page)='onPage($event.offset)'>
+      </ngx-datatable>
+    </div>
+  `
+})
+export class ServerScrollingComponent {
+  
+  lastPage = new Page();
+  rows = new Array<CorporateEmployee>();
+
+  constructor(private serverResultsService: MockServerResultsService) {
+    this.lastPage.pageNumber = -1;
+    this.lastPage.size = 5;
+  }
+
+  ngOnInit() {
+    this.addPage(0);
+    this.addPage(1);
+  }
+  
+  onPage(pageNumber: number) {
+    // pre-fetch the next page
+    if (this.lastPage.pageNumber === pageNumber) {
+      this.addPage(pageNumber + 1);
+    }
+  }
+
+  /**
+   * Populate the table with new data based on the page number
+   * @param pageNumber The page number to add
+   */
+  addPage(pageNumber: number){
+    // cache the new page, but only once
+    if (this.lastPage.pageNumber < pageNumber) {
+      this.lastPage.pageNumber++;
+      this.serverResultsService.getResults(this.lastPage).subscribe(pagedData => {
+        this.lastPage = pagedData.page;
+        this.rows = this.rows.concat(pagedData.data);
+      });
+    }
+  }
+}


### PR DESCRIPTION
This demo combines scrolling and server-side paging
to enable "infinite" scrolling with results fetched from
the server as the user scrolls down the list.

We always fetch the next page such that it is obvious
from the vertical scrollbar when there are more results.
This approach also helps us avoid explicit pixel calculation logic,
instead relying only on (page) events.

Once loaded, the results are never removed from the cache,
which increases memory consumption over time.
This is a minor hindrance, since in a typical scenario
(e.g. generation of the list in response to a "search" request),
we expect the most relevant results to appear at the top,
with progressively more "stale" results at the bottom,
so that a typical user won't scroll too far (e.g. beyond 100-200 results).
It is also well-known that such search queries consume
progressively more server resources and are not efficient
beyond e.g. 1000 results.

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Demo

**What is the current behavior?** (You can also link to an open issue here)
There are separate demos for virtual scrolling (when all of the results are fetched in advance)
and server-side paging (without vertical scrolling).

**What is the new behavior?**
We combine these together to enable "infinite" server-side scrolling.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information**:
This PR was requested by @amcdnl in https://github.com/swimlane/ngx-datatable/issues/611#issuecomment-299452014