### PR TITLE
Fix for backward selection with the Shift key

### DIFF
--- a/src/utils/selection.ts
+++ b/src/utils/selection.ts
@@ -28,7 +28,7 @@ export function selectRowsBetween(
     if (reverse) {
       range = {
         start: index,
-        end: (prevIndex - index)
+        end: prevIndex
       };
     } else {
       range = {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Multi selection selects wrong number of rows if user select with the Shift key from bottom to top.

**What is the new behavior?**
Multi selection with the shift key works correctly

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Steps to reproduce:
1. On the [multi selection demo](https://swimlane.github.io/ngx-datatable/#multi-selection) select last row (Georgina Schultz)
2. With the Shift key select second row (Claudine Neal)