### PR TITLE
Fix header template outlet context

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "tslint-config-swimlane": "^3.0.1",
     "tslint-loader": "^3.5.3",
     "typescript": "^2.3.3",
-    "uglifyjs": "^2.4.10",
+    "uglify-js": "^2.8.27",
     "url-loader": "^0.5.8",
     "webpack": "^2.6.1",
     "webpack-combine-loaders": "^2.0.3",

--- a/src/components/header/header-cell.component.ts
+++ b/src/components/header/header-cell.component.ts
@@ -1,9 +1,26 @@
 import {
-  Component, Input, EventEmitter, Output, HostBinding, HostListener
+  Component, Input, EventEmitter, Output, HostBinding, HostListener, ChangeDetectionStrategy, OnChanges, SimpleChanges,
+  OnInit
 } from '@angular/core';
 
 import { SortDirection, SortType, SelectionType, TableColumn } from '../../types';
 import { nextSortDir } from '../../utils';
+
+/**
+ * properties provided to the headerTemplate
+ */
+interface HeaderTemplateContext {
+  column: TableColumn;
+  sortDir: SortDirection;
+  sortFn: () => void;
+  allRowsSelected: boolean;
+  selectFn: (o: any) => void;
+}
+
+/**
+ * Input properties that if changed, should re-generate the headerTemplateContext
+ */
+const headerContextProps = ['column', 'sorts', 'allRowsSelected'];
 
 @Component({
   selector: 'datatable-header-cell',
@@ -30,13 +47,7 @@ import { nextSortDir } from '../../utils';
       <ng-template
         *ngIf="column.headerTemplate"
         [ngTemplateOutlet]="column.headerTemplate"
-        [ngOutletContext]="{ 
-          column: column, 
-          sortDir: sortDir,
-          sortFn: sortFn,
-          allRowsSelected: allRowsSelected,
-          selectFn: selectFn
-        }">
+        [ngOutletContext]="headerTemplateContext">
       </ng-template>
       <span
         (click)="onSort()"
@@ -46,10 +57,11 @@ import { nextSortDir } from '../../utils';
   `,
   host: {
     class: 'datatable-header-cell'
-  }
+  },
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 
-export class DataTableHeaderCellComponent {
+export class DataTableHeaderCellComponent implements OnInit, OnChanges {
 
   @Input() sortType: SortType;
   @Input() column: TableColumn;
@@ -141,9 +153,39 @@ export class DataTableHeaderCellComponent {
   _sorts: any[];
   selectFn = this.select.emit.bind(this.select);
 
+  private headerTemplateContext: HeaderTemplateContext;
+
+  private initialized: boolean;
+
   @HostListener('contextmenu', ['$event'])
   onContextmenu($event: MouseEvent): void {
     this.columnContextmenu.emit({ event: $event, column: this.column });
+  }
+
+  ngOnInit() {
+    this.updateHeaderTemplateContext();
+    this.initialized = true;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!this.initialized) return;
+    // determine if a property that affects headerTemplateContext has changed
+    for (const prop in headerContextProps) {
+      if (changes.hasOwnProperty(prop)) {
+        this.updateHeaderTemplateContext();
+        break;
+      }
+    }
+  }
+
+  private updateHeaderTemplateContext() {
+    this.headerTemplateContext = {
+      column: this.column,
+      sortDir: this.sortDir,
+      sortFn: this.sortFn,
+      allRowsSelected: this.allRowsSelected,
+      selectFn: this.selectFn
+    };
   }
 
   calcSortDir(sorts: any[]): any {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`headerTemplate` regenerates on every change detection.


**What is the new behavior?**

outletContext is only recreated when certain Input properties change.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Fixes #785 