### PR TITLE
Make Universal Support Typesafe

### DIFF
--- a/src/utils/elm-from-point.ts
+++ b/src/utils/elm-from-point.ts
@@ -1,4 +1,4 @@
-if (document !== undefined && !document.elementsFromPoint) {
+if (typeof document !== 'undefined' && !document.elementsFromPoint) {
   document.elementsFromPoint = elementsFromPoint;
 }
 

--- a/src/utils/prefixes.ts
+++ b/src/utils/prefixes.ts
@@ -1,14 +1,14 @@
 import { camelCase } from './camel-case';
 
 const cache = {};
-const testStyle = document !== undefined ? document.createElement('div').style : undefined;
+const testStyle = typeof document !== 'undefined' ? document.createElement('div').style : undefined;
 
 // Get Prefix
 // http://davidwalsh.name/vendor-prefix
 const prefix = (function() {
-  const styles = window !== undefined ? window.getComputedStyle(document.documentElement, '') : undefined;
-  const pre = styles !== undefined ? (Array.prototype.slice.call(styles).join('').match(/-(moz|webkit|ms)-/))[1] : undefined;
-  const dom = pre !== undefined ? ('WebKit|Moz|MS|O').match(new RegExp('(' + pre + ')', 'i'))[1] : undefined;
+  const styles = typeof window !== 'undefined' ? window.getComputedStyle(document.documentElement, '') : undefined;
+  const pre = typeof styles !== 'undefined' ? (Array.prototype.slice.call(styles).join('').match(/-(moz|webkit|ms)-/))[1] : undefined;
+  const dom = typeof pre !== 'undefined' ? ('WebKit|Moz|MS|O').match(new RegExp('(' + pre + ')', 'i'))[1] : undefined;
 
   return dom ? {
     dom,

--- a/src/utils/translate.ts
+++ b/src/utils/translate.ts
@@ -2,15 +2,15 @@ import { getVendorPrefixedName } from './prefixes';
 import { camelCase } from './camel-case';
 
 // browser detection and prefixing tools
-const transform = getVendorPrefixedName('transform');
-const backfaceVisibility = getVendorPrefixedName('backfaceVisibility');
-const hasCSSTransforms = !!getVendorPrefixedName('transform');
-const hasCSS3DTransforms = !!getVendorPrefixedName('perspective');
-const ua = window ? window.navigator.userAgent : "Chrome";
+const transform = typeof window !== 'undefined' ? getVendorPrefixedName('transform') : undefined;
+const backfaceVisibility = typeof window !== 'undefined' ? getVendorPrefixedName('backfaceVisibility') : undefined;
+const hasCSSTransforms = typeof window !== 'undefined' ? !!getVendorPrefixedName('transform') : undefined;
+const hasCSS3DTransforms = typeof window !== 'undefined' ? !!getVendorPrefixedName('perspective') : undefined;
+const ua = typeof window !== 'undefined' ? window.navigator.userAgent : "Chrome";
 const isSafari = (/Safari\//).test(ua) && !(/Chrome\//).test(ua);
 
 export function translateXY(styles: any, x: number, y: number) {
-  if (hasCSSTransforms) {
+  if (typeof transform !== 'undefined' && hasCSSTransforms) {
     if (!isSafari && hasCSS3DTransforms) {
       styles[transform] = `translate3d(${x}px, ${y}px, 0)`;
       styles[backfaceVisibility] = 'hidden';


### PR DESCRIPTION
Change the way checking for document and window is done for use in typesafe Angular Universal environment.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
#794 See Bug


**What is the new behavior?**
#794 See Bug


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information**:
Closes #764 
