### PR TITLE
Enhance server scrolling demo (740#issuecomment-310806538)

### DIFF
--- a/demo/paging/scrolling-server.component.css
+++ b/demo/paging/scrolling-server.component.css
@@ -1,0 +1,8 @@
+ngx-datatable {
+  height: calc(100vh - 110px);
+}
+
+ngx-datatable .progress-linear {
+  position: fixed !important;
+  bottom: 0px;
+}


### PR DESCRIPTION
We enhance "infinite" server-side scrolling example
by binding to (scroll) instead of (page) events.

We can now detect when the user scrolls down to the bottom
of the list, and load only as many results as needed,
until the user scrolls all the way down again.

We also add some styles to dynamically resize the list
according to user's viewport size, and to display
the progress indicator at the bottom of the list.

Overall, this provides a more natural "infinite" scrolling experience.

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Demo

**What is the current behavior?** (You can also link to an open issue here)
Server-side "infinite" scrolling has been accomplished using (page) events, which requires us to load a fixed large number of pages in advance (otherwise, the scrollbar may not appear on larger screens).

**What is the new behavior?**
We now bind to (scroll) events, which allows us to detect when the user scrolls all the way down the list,
and only load more results then.

In addition, the list now dynamically resizes according to user screen and shows the progress indicator at the bottom.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Please see https://github.com/swimlane/ngx-datatable/pull/740#issuecomment-310806538 for relevant discussion.