### PR TITLE
Prevent mutating original rows

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -324,7 +324,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     const temp: any[] = [];
 
     while (rowIndex < last && rowIndex < this.rowCount) {
-      const row = this.rows[rowIndex];
+      const row = Object.assign({}, this.rows[rowIndex]);
 
       if(row) {
         row.$$index = rowIndex;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
Currently `$$index` is set on the original object you pass to `rows`, because it's set by reference, thus polluting the original data.


**What is the new behavior?**
Now it makes a clean copy that it can modify internally


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No


**Other information**:
The original data should never be touched by the table.
