### PR TITLE
Fix errors " Cannot find name 'object' "

### DIFF
--- a/release/utils/column-prop-getters.d.ts
+++ b/release/utils/column-prop-getters.d.ts
@@ -24,10 +24,10 @@ export declare function numericIndexGetter(row: any[], index: number): any;
  * @param fieldName field name string
  * @returns {any}
  */
-export declare function shallowValueGetter(obj: object, fieldName: string): any;
+export declare function shallowValueGetter(obj: Object, fieldName: string): any;
 /**
  * Returns a deep object given a string. zoo['animal.type']
  * @param {object} obj
  * @param {string} path
  */
-export declare function deepValueGetter(obj: object, path: string): any;
+export declare function deepValueGetter(obj: Object, path: string): any;

--- a/src/utils/column-prop-getters.ts
+++ b/src/utils/column-prop-getters.ts
@@ -53,7 +53,7 @@ export function numericIndexGetter(row: any[], index: number): any {
  * @param fieldName field name string
  * @returns {any}
  */
-export function shallowValueGetter(obj: object, fieldName: string): any {
+export function shallowValueGetter(obj: Object, fieldName: string): any {
   if(!obj || !fieldName) return obj;
 
   const value = obj[fieldName];
@@ -66,7 +66,7 @@ export function shallowValueGetter(obj: object, fieldName: string): any {
  * @param {object} obj
  * @param {string} path
  */
-export function deepValueGetter(obj: object, path: string): any {
+export function deepValueGetter(obj: Object, path: string): any {
   if(!obj || !path) return obj;
 
   // check if path matches a root-level field


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
ERROR in .../node_modules/@swimlane/ngx-datatable/src/utils/column-prop-getters.ts (56,41): Cannot find name 'object'.

ERROR in .../node_modules/@swimlane/ngx-datatable/src/utils/column-prop-getters.ts (69,38): Cannot find name 'object'.

ERROR in .../node_modules/@swimlane/ngx-datatable/release/utils/column-prop-getters.d.ts (27,49): Cannot find name 'object'.

ERROR in .../node_modules/@swimlane/ngx-datatable/release/utils/column-prop-getters.d.ts (33,46): Cannot find name 'object'.


**What is the new behavior?**
No error


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
