### PR TITLE
Center active page in pagiator

### DIFF
--- a/src/components/footer/pager.component.ts
+++ b/src/components/footer/pager.component.ts
@@ -136,8 +136,16 @@ export class DataTablePagerComponent {
     page = page || this.page;
 
     if (isMaxSized) {
-      startPage = ((Math.ceil(page / maxSize) - 1) * maxSize) + 1;
-      endPage = Math.min(startPage + maxSize - 1, this.totalPages);
+      startPage = page-Math.floor(maxSize/2);
+      endPage = page+Math.floor(maxSize/2), this.totalPages;
+
+      if(startPage <1){
+        startPage = 1;
+        endPage = startPage+maxSize-1;
+      }else if(endPage > this.totalPages){
+        startPage = this.totalPages-maxSize+1;
+        endPage = this.totalPages;
+      }
     }
 
     for (let num = startPage; num <= endPage; num++) {

--- a/src/components/footer/pager.component.ts
+++ b/src/components/footer/pager.component.ts
@@ -136,14 +136,14 @@ export class DataTablePagerComponent {
     page = page || this.page;
 
     if (isMaxSized) {
-      startPage = page-Math.floor(maxSize/2);
-      endPage = page+Math.floor(maxSize/2), this.totalPages;
+      startPage = page - Math.floor(maxSize / 2);
+      endPage = page + Math.floor(maxSize / 2), this.totalPages;
 
-      if(startPage <1){
+      if(startPage < 1){
         startPage = 1;
-        endPage = startPage+maxSize-1;
+        endPage = Math.max(startPage + maxSize - 1, this.totalPages);
       }else if(endPage > this.totalPages){
-        startPage = this.totalPages-maxSize+1;
+        startPage = Math.max(this.totalPages - maxSize + 1, 1);
         endPage = this.totalPages;
       }
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Only the first 5 pages are shown, to get to page 6 you need to select page 5 and then click on the 'next page' arrow.


**What is the new behavior?**
The active page is centered in the pager. If page 6 is active, the pager will look like this:
![screen shot 2017-07-17 at 13 30 30](https://user-images.githubusercontent.com/5055413/28267152-00135644-6af9-11e7-86aa-9a4dc7f6bd24.png)


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
