### PR TITLE
Fix to the header select all checkbox client side pagination bug and Configurable footer postion

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -660,17 +660,11 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
   /**
    * Returns if all rows are selected.
    *
-   * @readonly
    * @private
    * @type {boolean}
    * @memberOf DatatableComponent
    */
-  get allRowsSelected(): boolean {
-    return this.selected &&
-      this.rows &&
-      this.rows.length !== 0 &&
-      this.selected.length === this.rows.length;
-  }
+  allRowsSelected: boolean;
 
   element: HTMLElement;
   innerWidth: number;
@@ -848,6 +842,12 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    * @memberOf DatatableComponent
    */
   onBodyPage({offset}: any): void {
+    this.selected = [];
+    this.allRowsSelected = false;
+    this.select.emit({
+      selected: this.selected
+    });
+    
     this.offset = offset;
 
     this.page.emit({
@@ -878,6 +878,12 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    * @memberOf DatatableComponent
    */
   onFooterPage(event: any) {
+    this.selected = [];
+    this.allRowsSelected = false;
+    this.select.emit({
+      selected: this.selected
+    });
+    
     this.offset = event.page - 1;
     this.bodyComponent.updateOffsetY(this.offset);
 
@@ -1026,6 +1032,12 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    * @memberOf DatatableComponent
    */
   onColumnSort(event: any): void {
+    this.selected = [];
+    this.allRowsSelected = false;
+    this.select.emit({
+      selected: this.selected
+    });
+    
     const {sorts} = event;
 
     // this could be optimized better since it will resort
@@ -1056,9 +1068,18 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
     // remove all existing either way
     this.selected = [];
 
-    // do the opposite here
-    if (!allSelected) {
-      this.selected.push(...this.rows);
+    if (this.allRowsSelected) {
+      if (!this.externalPaging) {
+        const auxList = [];
+        auxList.push(...this.rows);
+        this.selected = auxList.slice(this.offset * this.limit, ((this.offset + 1) * this.limit));
+      }
+      else {
+        this.selected.push(...this.rows);
+      }
+    }
+    else {
+      this.selected = [];
     }
 
     this.select.emit({
@@ -1074,6 +1095,13 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    * @memberOf DatatableComponent
    */
   onBodySelect(event: any): void {
+    if (this.selected.length === this.limit && !this.allRowsSelected && this.rows.length > 0) {
+      this.allRowsSelected = true;
+    }
+    else {
+      this.allRowsSelected = false;
+    }
+    
     this.select.emit(event);
   }
 

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -23,6 +23,22 @@ import { MouseEvent } from '../events';
     <div
       visibilityObserver
       (visible)="recalculate()">
+      <datatable-footer
+        *ngIf="footerHeight && (footerPosition == 'top' || footerPosition == 'both')"
+        [rowCount]="rowCount"
+        [pageSize]="pageSize"
+        [offset]="offset"
+        [footerHeight]="footerHeight"
+        [footerTemplate]="footer"
+        [totalMessage]="messages.totalMessage"
+        [pagerLeftArrowIcon]="cssClasses.pagerLeftArrow"
+        [pagerRightArrowIcon]="cssClasses.pagerRightArrow"
+        [pagerPreviousIcon]="cssClasses.pagerPrevious"
+        [selectedCount]="selected.length"
+        [selectedMessage]="!!selectionType && messages.selectedMessage"
+        [pagerNextIcon]="cssClasses.pagerNext"
+        (page)="onFooterPage($event)">
+      </datatable-footer>
       <datatable-header
         *ngIf="headerHeight"
         [sorts]="sorts"
@@ -72,7 +88,7 @@ import { MouseEvent } from '../events';
         (scroll)="onBodyScroll($event)">
       </datatable-body>
       <datatable-footer
-        *ngIf="footerHeight"
+        *ngIf="footerHeight && (footerPosition == 'bottom' || footerPosition == 'both')"
         [rowCount]="rowCount"
         [pageSize]="pageSize"
         [offset]="offset"
@@ -210,6 +226,15 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    * @memberOf DatatableComponent
    */
   @Input() footerHeight: number = 0;
+  
+  /**
+   * To display footer postion at the top or bottom or in both places of the table.
+   * Default value: `bottom`
+   *
+   * @type {string}
+   * @memberOf DatatableComponent
+   */
+  @Input() footerPosition: string = 'bottom';
 
   /**
    * If the table should use external paging
@@ -1061,10 +1086,8 @@ export class DatatableComponent implements OnInit, AfterViewInit, DoCheck {
    *
    * @memberOf DatatableComponent
    */
-  onHeaderSelect(event: any): void {
-    // before we splice, chk if we currently have all selected
-    const allSelected = this.selected.length === this.rows.length;
-
+  onHeaderSelect(event: boolean): void {
+    this.allRowsSelected = event;
     // remove all existing either way
     this.selected = [];
 

--- a/src/components/footer/pager.component.ts
+++ b/src/components/footer/pager.component.ts
@@ -141,7 +141,7 @@ export class DataTablePagerComponent {
 
       if(startPage < 1){
         startPage = 1;
-        endPage = Math.max(startPage + maxSize - 1, this.totalPages);
+        endPage = Math.min(startPage + maxSize - 1, this.totalPages);
       }else if(endPage > this.totalPages){
         startPage = Math.max(this.totalPages - maxSize + 1, 1);
         endPage = this.totalPages;


### PR DESCRIPTION
In client side pagination select all checkbox selecting all the records(rows) in all pages. This fix is to select only existing records(rows) in the current page.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
There is on PR(#736) for this. But have lot of conflicts and not fixed it completly.

_**Client side pagination:**_
If I click select all check box in the header while I have pagination it returning all the rows of all pages. 

**_New feature: Footer Position_** 
There is one PR #751 for this.
Footer(Pagination with summary) display at the end of the table only.


**What is the new behavior?**

_**Client side pagination:**_
If I click select all check box in the header while I have pagination it will return only rows of the current page.
I am going to remove selected rows in the following usecases
1. On page change
2. On coulmn sorting


**_New feature: Footer Position_**
PR #751 will be solved.
Footer(Pagination with summary) display is now configurable with the following options for **footerPosition** input varaible
1. Bottom 2. Top 3. Both


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
