### PR TITLE
prevent headerTemplate outlet context from regenerating on every change.

### DIFF
--- a/src/components/header/header-cell.component.ts
+++ b/src/components/header/header-cell.component.ts
@@ -1,9 +1,26 @@
 import {
-  Component, Input, EventEmitter, Output, HostBinding, HostListener
+  Component, Input, EventEmitter, Output, HostBinding, HostListener, ChangeDetectionStrategy, OnChanges, SimpleChanges,
+  OnInit
 } from '@angular/core';
 import { SortDirection, SortType, SelectionType, TableColumn } from '../../types';
 import { nextSortDir } from '../../utils';
 import { mouseEvent } from '../../events';
+
+/**
+ * properties provided to the headerTemplate
+ */
+interface HeaderTemplateContext {
+  column: TableColumn;
+  sortDir: SortDirection;
+  sortFn: () => void;
+  allRowsSelected: boolean;
+  selectFn: (o: any) => void;
+}
+
+/**
+ * Input properties that if changed, should re-generate the headerTemplateContext
+ */
+const headerContextProps = ['column', 'sorts', 'allRowsSelected'];
 
 @Component({
   selector: 'datatable-header-cell',
@@ -30,13 +47,7 @@ import { mouseEvent } from '../../events';
       <ng-template
         *ngIf="column.headerTemplate"
         [ngTemplateOutlet]="column.headerTemplate"
-        [ngOutletContext]="{
-          column: column,
-          sortDir: sortDir,
-          sortFn: sortFn,
-          allRowsSelected: allRowsSelected,
-          selectFn: selectFn
-        }">
+        [ngOutletContext]="headerTemplateContext">
       </ng-template>
       <span
         (click)="onSort()"
@@ -46,10 +57,11 @@ import { mouseEvent } from '../../events';
   `,
   host: {
     class: 'datatable-header-cell'
-  }
+  },
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 
-export class DataTableHeaderCellComponent {
+export class DataTableHeaderCellComponent implements OnInit, OnChanges {
 
   @Input() sortType: SortType;
   @Input() column: TableColumn;
@@ -141,9 +153,29 @@ export class DataTableHeaderCellComponent {
   _sorts: any[];
   selectFn = this.select.emit.bind(this.select);
 
+  private headerTemplateContext: HeaderTemplateContext;
+
+  private initialized: boolean;
+
   @HostListener('contextmenu', ['$event'])
   onContextmenu($event: MouseEvent): void {
     this.columnContextmenu.emit({ event: $event, column: this.column });
+  }
+
+  ngOnInit() {
+    this.updateHeaderTemplateContext();
+    this.initialized = true;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!this.initialized) return;
+    // determine if a property that affects headerTemplateContext has changed
+    for (const prop in headerContextProps) {
+      if (changes.hasOwnProperty(prop)) {
+        this.updateHeaderTemplateContext();
+        break;
+      }
+    }
   }
 
   calcSortDir(sorts: any[]): any {
@@ -175,6 +207,16 @@ export class DataTableHeaderCellComponent {
     } else {
       return `sort-btn`;
     }
+  }
+
+  private updateHeaderTemplateContext() {
+    this.headerTemplateContext = {
+      column: this.column,
+      sortDir: this.sortDir,
+      sortFn: this.sortFn,
+      allRowsSelected: this.allRowsSelected,
+      selectFn: this.selectFn
+    };
   }
 
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
#785 


**What is the new behavior?**
Modified **DataTableHeaderCellComponent**
A new outlet context object will only be created when one of its properties changes. Triggered by ngOnChanges.
Also added `changeDetection: ChangeDetectionStrategy.OnPush`


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: 

Shouldn't break existing code unless the OnPush change detection change causes issues for people who are mutating objects instead of setting Inputs.

**Other information**:
