### PR TITLE
(feat) Row Selection - Add in rowIndex to select output

### DIFF
--- a/src/components/body/selection.component.ts
+++ b/src/components/body/selection.component.ts
@@ -68,7 +68,8 @@ export class DataTableSelectionComponent {
     this.prevIndex = index;
 
     this.select.emit({
-      selected
+        selected,
+        rowIndex: index
     });
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently you have no clue what row index was on the selected row now that $$index is removed. 


**What is the new behavior?**
This allows you to get the row index of the selected row when a row is selected.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
