### PR TITLE
Returns empty string if row is null. Fixes #951

### DIFF
--- a/src/utils/column-prop-getters.ts
+++ b/src/utils/column-prop-getters.ts
@@ -38,6 +38,7 @@ export function getterForProp(prop: TableColumnProp): ValueGetter {
  * @returns {any} or '' if invalid index
  */
 export function numericIndexGetter(row: any[], index: number): any {
+  if (row == null) return '';
   // mimic behavior of deepValueGetter
   if (!row || index == null) return row;
 
@@ -54,6 +55,7 @@ export function numericIndexGetter(row: any[], index: number): any {
  * @returns {any}
  */
 export function shallowValueGetter(obj: any, fieldName: string): any {
+  if (obj == null) return '';
   if(!obj || !fieldName) return obj;
 
   const value = obj[fieldName];
@@ -67,6 +69,7 @@ export function shallowValueGetter(obj: any, fieldName: string): any {
  * @param {string} path
  */
 export function deepValueGetter(obj: any, path: string): any {
+  if (obj == null) return '';
   if(!obj || !path) return obj;
 
   // check if path matches a root-level field


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Before would return row if falsy. That behavior is okay for a value of `0` but not null or undefined. This seems to only be a problem in IE or Edge.

**What is the new behavior?**

Returns empty string if row is null. 

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
