### PR TITLE
Fixes IE & Edge displaying null for no column name

### DIFF
--- a/src/utils/column-helper.ts
+++ b/src/utils/column-helper.ts
@@ -26,8 +26,12 @@ export function setColumnDefaults(columns: TableColumn[]) {
     }
 
     // format props if no name passed
-    if(column.prop != null && !column.name) {
+    if(column.prop != null && column.name == null) {
       column.name = deCamelCase(String(column.prop));
+    }
+    
+    if(column.prop == null && column.name == null) {
+      column.name = ''; // Fixes IE and Edge displaying `null`
     }
 
     if(!column.hasOwnProperty('resizeable')) {

--- a/src/utils/column-helper.ts
+++ b/src/utils/column-helper.ts
@@ -17,7 +17,7 @@ export function setColumnDefaults(columns: TableColumn[]) {
 
     // prop can be numeric; zero is valid not a missing prop
     // translate name => prop
-    if(column.prop == null && column.name) {
+    if(isNullOrUndefined(column.prop) && column.name) {
       column.prop = camelCase(column.name);
     }
 
@@ -26,11 +26,11 @@ export function setColumnDefaults(columns: TableColumn[]) {
     }
 
     // format props if no name passed
-    if(column.prop != null && column.name == null) {
+    if(!isNullOrUndefined(column.prop) && isNullOrUndefined(column.name)) {
       column.name = deCamelCase(String(column.prop));
     }
     
-    if(column.prop == null && column.name == null) {
+    if(isNullOrUndefined(column.prop) && isNullOrUndefined(column.name)) {
       column.name = ''; // Fixes IE and Edge displaying `null`
     }
 
@@ -54,6 +54,10 @@ export function setColumnDefaults(columns: TableColumn[]) {
       column.width = 150;
     }
   }
+}
+
+export function isNullOrUndefined<T>(value: T | null | undefined): value is null | undefined {
+    return value === null || value === undefined;
 }
 
 /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

IE & Edge display null in header column when column name and property are undefined. Also case where prop is set and name is `0`. Name will be converted to prop.

**What is the new behavior?**

Header column will no longer display null when column name and property are undefined. Also fixes case where prop is set and name is `0`. Name will no longer be converted to prop.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

<img width="602" alt="null" src="https://user-images.githubusercontent.com/8039397/30222737-db2e441c-9495-11e7-9c16-42144dcfe0f6.png">
