### PR TITLE
Doesn't delete row expansions when changing rows

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -119,7 +119,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
 
   @Input() set rows(val: any[]) {
     this._rows = val;
-    this.rowExpansions.clear();
+    this.groupsInit = false;
     this.recalcLayout();
   }
 
@@ -216,7 +216,8 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   rowTrackingFn: any;
   listener: any;
   rowIndexes: any = new Map();
-  rowExpansions: any = new Map();
+  rowExpansions: any = new WeakMap();
+  groupsInit: boolean = false;
 
   _rows: any[];
   _bodyHeight: any;
@@ -601,7 +602,8 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    */
   toggleAllRows(expanded: boolean): void {
     // clear prev expansions
-    this.rowExpansions.clear();
+    this.groupsInit = false;
+    this.rowExpansions = new WeakMap();
 
     const rowExpanded = expanded ? 1 : 0;
 
@@ -668,7 +670,8 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    * Returns if the row was expanded and set default row expansion when row expansion is empty
    */
   getRowExpanded(row: any): boolean {
-    if (this.rowExpansions.size === 0 && this.groupExpansionDefault) {
+    if (!this.groupsInit && this.groupExpansionDefault) {
+      this.groupsInit = true;
       for (const group of this.groupedRows) {
         this.rowExpansions.set(group, 1);
       }


### PR DESCRIPTION
I tried not to touch row grouping other than checking the size (WeakMap doesn't have capability), but that may still be buggy.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Every time you refresh rows i.e. `this.rows = [...this.rows];` like you suggest, it clears the list of expanded rows. But if you don't clear the list of expanded rows, then you could have a memory leak. I would recommend using a WeakMap.

**What is the new behavior?**

Expanded Rows mapping is not deleted until no longer referenced.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
