### PR TITLE
Make Selection global to all rows Fixes #974

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -13,7 +13,7 @@ import { mouseEvent } from '../../events';
     <datatable-selection
       #selector
       [selected]="selected"
-      [rows]="temp"
+      [rows]="rows"
       [selectCheck]="selectCheck"
       [selectEnabled]="selectEnabled"
       [selectionType]="selectionType"
@@ -55,7 +55,7 @@ import { mouseEvent } from '../../events';
             [rowIndex]="getRowIndex(group)"
             [expanded]="getRowExpanded(group)"            
             [rowClass]="rowClass"
-            (activate)="selector.onActivate($event, i)">
+            (activate)="selector.onActivate($event, indexes.first + i)">
           </datatable-body-row>                       
           <datatable-body-row
             *ngFor="let row of group.value; let i = index; trackBy: rowTrackingFn;"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Selection of rows is limited to current view

**What is the new behavior?**

Open up selection to be global to all rows

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
~~The onActivate event emits the viewIndex instead of the sorted row Index~~ This doesn't matter since it doesn't emit any index. I was looking at the function parameters which now use a different index. Not a breaking change.

**Other information**:
