### PR TITLE
Adds bounds to offset Fixes #978

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -283,7 +283,12 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    * The current offset ( page - 1 ) shown.
    * Default value: `0`
    */
-  @Input() offset: number = 0;
+  @Input() set offset(val: number) {
+    this._offset = val;
+  }
+  get offset(): number {
+    return Math.max(Math.min(this._offset, Math.ceil(this.rowCount / this.pageSize) - 1), 0);
+  }
 
   /**
    * Show the linear loading bar.
@@ -595,6 +600,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
 
   _limit: number | undefined;
   _count: number = 0;
+  _offset: number = 0;
   _rows: any[];
   _groupRowsBy: string;
   _internalRows: any[];


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`offset` is unbounded

**What is the new behavior?**

`offset` is bounded between `0` and the max page offset.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

This is important when changing other properties such as `limit` to readjust the offset. This does not address having the offset match where it used to be in the collection, just to make sure it does not display empty because it's out of bounds.
