### PR TITLE
(feature) Add an option to only use pager when using scrollbarv and external pager

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -335,7 +335,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
       offset = Math.ceil(offset);
     }
 
-    if (direction !== undefined && !isNaN(offset)) {
+    if (this.scrollbarV && direction !== undefined && !isNaN(offset)) {
       this.page.emit({ offset });
     }
   }

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -335,7 +335,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
       offset = Math.ceil(offset);
     }
 
-    if (this.scrollbarV && direction !== undefined && !isNaN(offset)) {
+    if (direction !== undefined && !isNaN(offset)) {
       this.page.emit({ offset });
     }
   }

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -782,7 +782,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   recalculatePages(): void {
     this.pageSize = this.calcPageSize();
     this.rowCount = this.calcRowCount();
-    this.bodyRowCount = this.onlyPagerToChangePage ? this.limit : this.rowCount;
+    this.bodyRowCount = this.onlyPagerToChangePage ? this.pageSize : this.rowCount;
   }
 
   /**
@@ -835,7 +835,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
     // Keep the page size constant even if the row has been expanded.
     // This is because an expanded row is still considered to be a child of
     // the original row.  Hence calculation would use rowHeight only.
-    if (this.scrollbarV) {      
+    if (this.scrollbarV && !this.onlyPagerToChangePage) {
       const size = Math.ceil(this.bodyHeight / this.rowHeight);
       return Math.max(size, 0);
     }

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -208,6 +208,11 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   @Input() scrollbarH: boolean = false;
 
   /**
+   * Weather or not use only page to change page
+   */
+  @Input() onlyPagerToChangePage: boolean = false;
+
+  /**
    * The row height; which is necessary
    * to calculate the height for the lazy rendering.
    */
@@ -782,14 +787,16 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    * Body triggered a page event.
    */
   onBodyPage({ offset }: any): void {
-    this.offset = offset;
+    if (!this.onlyPagerToChangePage) {
+      this.offset = offset;
 
-    this.page.emit({
-      count: this.count,
-      pageSize: this.pageSize,
-      limit: this.limit,
-      offset: this.offset
-    });
+      this.page.emit({
+        count: this.count,
+        pageSize: this.pageSize,
+        limit: this.limit,
+        offset: this.offset
+      });
+    }
   }
 
   /**
@@ -805,7 +812,11 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    */
   onFooterPage(event: any) {
     this.offset = event.page - 1;
-    this.bodyComponent.updateOffsetY(this.offset);
+    if (this.onlyPagerToChangePage) {
+      this.bodyComponent.updateOffsetY();
+    } else {
+      this.bodyComponent.updateOffsetY(this.offset);
+    }
 
     this.page.emit({
       count: this.count,

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -56,7 +56,7 @@ import { mouseEvent } from '../events';
         [loadingIndicator]="loadingIndicator"
         [externalPaging]="externalPaging"
         [rowHeight]="rowHeight"
-        [rowCount]="rowCount"
+        [rowCount]="bodyRowCount"
         [offset]="offset"
         [trackByProp]="trackByProp"
         [columns]="_internalColumns"
@@ -600,6 +600,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   pageSize: number;
   bodyHeight: number;
   rowCount: number = 0;
+  bodyRowCount: number = 0;
   offsetX: number = 0;
   rowDiffer: KeyValueDiffer<{}, {}>;
 
@@ -781,6 +782,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   recalculatePages(): void {
     this.pageSize = this.calcPageSize();
     this.rowCount = this.calcRowCount();
+    this.bodyRowCount = this.onlyPagerToChangePage ? this.limit : this.rowCount;
   }
 
   /**

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -208,7 +208,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   @Input() scrollbarH: boolean = false;
 
   /**
-   * Weather or not use only page to change page
+   * Weather or not to use only the footer pager to change page
    */
   @Input() onlyPagerToChangePage: boolean = false;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Page change event is triggered from the footer and when scrolling content

**What is the new behavior?**
You can use onlyPagerToChangePage to force paging events to happen only from the footer.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
This allows me to have scrollbarV and externalPager true.
Goal is to have sticky header, horzontal & vertical scroll and server-side pages.