### PR TITLE
(fix) sorting not working when updating rows on a datatable without columns property

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -691,7 +691,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   ngDoCheck(): void {
     if (this.rowDiffer.diff(this.rows)) {
       if (!this.externalSorting) {
-        this._internalRows = sortRows(this._rows, this.columns, this.sorts);
+        this._internalRows = sortRows(this._rows, this._internalColumns, this.sorts);
       } else {
         this._internalRows = [...this.rows];
       }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Rows are not sorted properly when updating the rows property and the columns property is not defined.

```
<ngx-datatable [rows]="rows" [sorts]="sorts"> <!-- no [columns] ! -->
  <ngx-datatable-column name="Date" [width]="80" [prop]="'date'">
    <ng-template let-listEntry="row" ngx-datatable-cell-template>
      {{listEntry.date | date:'dd.MM.y'}}
    </ng-template>
  </ngx-datatable-column>
</ngx-datatable>
```

I created a repo project: https://github.com/luchsamapparat/ngx-datatable-sort-bug

The cause for this issue is, that `ngDoCheck` calls `sortRows` with `this.columns`. `ngAfterViewInit` uses `this._internalColumns` which works fine even when the `[columns]` property is not set on the component.

**What is the new behavior?**

`ngDoCheck` sorts the rows correctly even when the `[columns]` property is not defined.

**Does this PR introduce a breaking change?** (check one with "x")
- [x] No
