### PR TITLE
Fix cell overflow when height is not fixed

### DIFF
--- a/src/components/datatable.component.scss
+++ b/src/components/datatable.component.scss
@@ -100,6 +100,7 @@
 
   .datatable-body-cell,
   .datatable-header-cell {
+    overflow-x: hidden;
     vertical-align: top;
     display: inline-block;
     line-height: 1.625;


### PR DESCRIPTION
[multiple-tables](http://swimlane.github.io/ngx-datatable/#multiple-tables) demo cells overflow on second table where `[rowHeight]="'auto'"`

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

css overflows outside cell when row height is not fixed and column width is too small to fix content.

**What is the new behavior?**

css overflow is hidden outside cell when row height is not fixed and column width is too small to fix content.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

<img width="651" alt="overflow-x" src="https://user-images.githubusercontent.com/8039397/31196955-87a1bfc6-a91d-11e7-846d-42d4befbb8af.png">
