### PR TITLE
Fix visiblility stops check after positive result

### DIFF
--- a/src/directives/visibility.directive.ts
+++ b/src/directives/visibility.directive.ts
@@ -51,10 +51,10 @@ export class VisibilityDirective implements OnInit, OnDestroy {
         this.onVisibilityChange();
       } else {
         clearTimeout(this.timeout);
-        this.zone.runOutsideAngular(() => {
-          this.timeout = setTimeout(() => check(), 50);
-        });
       }
+      this.zone.runOutsideAngular(() => {
+        this.timeout = setTimeout(() => check(), 50);
+      });
     };
 
     this.timeout = setTimeout(() => check());


### PR DESCRIPTION
The visibility directive stops check after the first positive result. This is be problematic when visibility toggles between visible and hidden more than once.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Toggle the table hidden and visible more than once. The body renders incorrectly.

**What is the new behavior?**

Toggle the table hidden and visible more than once. The body renders correctly.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

![hidden-resize](https://user-images.githubusercontent.com/8039397/31206410-a7f71334-a945-11e7-8db0-c49fe822363f.gif)
