### PR TITLE
Fixes #1032

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -44,7 +44,7 @@ import { mouseEvent } from '../../events';
           [rowIndex]="getRowIndex(group[i])"
           (rowContextmenu)="rowContextmenu.emit($event)">
           <datatable-body-row 
-            *ngIf="!group.value"        
+            *ngIf="!groupedRows; else groupedRowsTemplate"        
             tabindex="-1"
             [isSelected]="selector.getRowSelected(group)"
             [innerWidth]="innerWidth"
@@ -56,22 +56,24 @@ import { mouseEvent } from '../../events';
             [expanded]="getRowExpanded(group)"            
             [rowClass]="rowClass"
             (activate)="selector.onActivate($event, indexes.first + i)">
-          </datatable-body-row>                       
-          <datatable-body-row
-            *ngFor="let row of group.value; let i = index; trackBy: rowTrackingFn;"
-            tabindex="-1"
-            [isSelected]="selector.getRowSelected(row)"
-            [innerWidth]="innerWidth"
-            [offsetX]="offsetX"
-            [columns]="columns"
-            [rowHeight]="getRowHeight(row)"
-            [row]="row"
-            [group]="group.value"
-            [rowIndex]="getRowIndex(row)"
-            [expanded]="getRowExpanded(row)"
-            [rowClass]="rowClass"
-            (activate)="selector.onActivate($event, i)">
           </datatable-body-row>
+          <ng-template #groupedRowsTemplate>
+            <datatable-body-row
+              *ngFor="let row of group.value; let i = index; trackBy: rowTrackingFn;"
+              tabindex="-1"
+              [isSelected]="selector.getRowSelected(row)"
+              [innerWidth]="innerWidth"
+              [offsetX]="offsetX"
+              [columns]="columns"
+              [rowHeight]="getRowHeight(row)"
+              [row]="row"
+              [group]="group.value"
+              [rowIndex]="getRowIndex(row)"
+              [expanded]="getRowExpanded(row)"
+              [rowClass]="rowClass"
+              (activate)="selector.onActivate($event, i)">
+            </datatable-body-row>
+          </ng-template>
         </datatable-row-wrapper>
       </datatable-scroller>
       <div


### PR DESCRIPTION
`groupedRows` should be checked instead of `group.value`. In addition, if `group.value` contains a value from a non-grouped rows, it will try to iterate it. This should fix that by making this an if-else template instead of an if template with an `ngForOf` template.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

non-grouped rows cannot have `value` as a property.

**What is the new behavior?**

non-grouped rows can have `value` as a property.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
