### PR TITLE
Implemented [displayCheck] Input

### DIFF
--- a/demo/selection/selection-chkbox.component.ts
+++ b/demo/selection/selection-chkbox.component.ts
@@ -29,6 +29,7 @@ import { Component } from '@angular/core';
           [limit]="5"
           [selected]="selected"
           [selectionType]="'checkbox'"
+          [displayCheck]="displayCheck"
           (activate)="onActivate($event)"
           (select)='onSelect($event)'>
           <ngx-datatable-column
@@ -103,4 +104,7 @@ export class CheckboxSelectionComponent {
     this.selected = [];
   }
 
+  displayCheck(row) {
+    return row.name !== 'Ethel Price';
+  }
 }

--- a/docs/api/table/inputs.md
+++ b/docs/api/table/inputs.md
@@ -102,6 +102,14 @@ to select a particular row based on a criteria. Example:
 (row, column, value) => { return value !== 'Ethel Price'; }
 ```
 
+## `displayCheck`
+A function you can use to check whether you want
+to show the checkbox for a particular row based on a criteria. Example:
+
+```
+(row) => { return row.name !== 'Ethel Price'; }
+```
+
 ## `selected`
 List of row objects that should be represented as selected in the grid. It does object
 equality, for prop checking use the `selectCheck` function.

--- a/docs/api/table/inputs.md
+++ b/docs/api/table/inputs.md
@@ -107,7 +107,7 @@ A function you can use to check whether you want
 to show the checkbox for a particular row based on a criteria. Example:
 
 ```
-(row) => { return row.name !== 'Ethel Price'; }
+(row, column, value) => { return row.name !== 'Ethel Price'; }
 ```
 
 ## `selected`

--- a/src/components/body/body-cell.component.ts
+++ b/src/components/body/body-cell.component.ts
@@ -15,7 +15,7 @@ import { mouseEvent, keyboardEvent } from '../../events';
   template: `
     <div class="datatable-body-cell-label">
       <label
-        *ngIf="column.checkboxable && (!displayCheck || displayCheck(row))"
+        *ngIf="column.checkboxable && (!displayCheck || displayCheck(row, column, value))"
         class="datatable-checkbox">
         <input
           type="checkbox"

--- a/src/components/body/body-cell.component.ts
+++ b/src/components/body/body-cell.component.ts
@@ -15,7 +15,7 @@ import { mouseEvent, keyboardEvent } from '../../events';
   template: `
     <div class="datatable-body-cell-label">
       <label
-        *ngIf="column.checkboxable"
+        *ngIf="column.checkboxable && (!displayCheck || displayCheck(row))"
         class="datatable-checkbox">
         <input
           type="checkbox"
@@ -37,6 +37,8 @@ import { mouseEvent, keyboardEvent } from '../../events';
   `
 })
 export class DataTableBodyCellComponent implements DoCheck, OnDestroy {
+  @Input() displayCheck: any;
+
   @Input() set group(group: any){
     this._group = group;
     this.cellContext.group = group;

--- a/src/components/body/body-row.component.ts
+++ b/src/components/body/body-row.component.ts
@@ -27,6 +27,7 @@ import { mouseEvent, keyboardEvent } from '../../events';
         [rowIndex]="rowIndex"
         [column]="column"
         [rowHeight]="rowHeight"
+        [displayCheck]="displayCheck"
         (activate)="onActivate($event, ii)">
       </datatable-body-cell>
     </div>      
@@ -64,6 +65,7 @@ export class DataTableBodyRowComponent implements DoCheck {
   @Input() offsetX: number;
   @Input() isSelected: boolean;
   @Input() rowIndex: number;
+  @Input() displayCheck: any;
 
   @HostBinding('class')
   get cssClass() {

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -55,6 +55,7 @@ import { mouseEvent } from '../../events';
             [rowIndex]="getRowIndex(group)"
             [expanded]="getRowExpanded(group)"            
             [rowClass]="rowClass"
+            [displayCheck]="displayCheck"
             (activate)="selector.onActivate($event, indexes.first + i)">
           </datatable-body-row>
           <ng-template #groupedRowsTemplate>
@@ -103,6 +104,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   @Input() rowDetail: any;
   @Input() groupHeader: any;
   @Input() selectCheck: any;
+  @Input() displayCheck: any;
   @Input() trackByProp: string;
   @Input() rowClass: any;
   @Input() groupedRows: any;

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -390,7 +390,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    * A function you can use to check whether you want
    * to show the checkbox for a particular row based on a criteria. Example:
    *
-   *    (row) => {
+   *    (row, column, value) => {
    *      return row.name !== 'Ethel Price';
    *    }
    */

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -72,6 +72,7 @@ import { mouseEvent } from '../events';
         [rowIdentity]="rowIdentity"
         [rowClass]="rowClass"
         [selectCheck]="selectCheck"
+        [displayCheck]="displayCheck"
         (page)="onBodyPage($event)"
         (activate)="activate.emit($event)"
         (rowContextmenu)="onRowContextmenu($event)"
@@ -384,6 +385,16 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    *    }
    */
   @Input() selectCheck: any;
+
+  /**
+   * A function you can use to check whether you want
+   * to show the checkbox for a particular row based on a criteria. Example:
+   *
+   *    (row) => {
+   *      return row.name !== 'Ethel Price';
+   *    }
+   */
+  @Input() displayCheck: any;
 
   /**
    * A boolean you can use to set the detault behaviour of rows and groups

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -394,7 +394,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    *      return row.name !== 'Ethel Price';
    *    }
    */
-  @Input() displayCheck: any;
+  @Input() displayCheck: (row, column?, value?) => boolean;
 
   /**
    * A boolean you can use to set the detault behaviour of rows and groups


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Feature

**What is the current behavior?** (You can also link to an open issue here)

There is no way to filter the checkable rows. See #1000 

**What is the new behavior?**

A new `[displayCheck]` input as a function that filters the rows.

**Does this PR introduce a breaking change?** (check one with "x")
- [x] No

