### PR TITLE
Allow sorting grouped table rows and reverting to ungrouped state

### DIFF
--- a/src/components/body/body-row-wrapper.component.ts
+++ b/src/components/body/body-row-wrapper.component.ts
@@ -9,7 +9,7 @@ import { mouseEvent } from '../../events';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div 
-      *ngIf="groupHeader && groupHeader.template"
+      *ngIf="groupHeader && groupHeader.template && row?.value"
       class="datatable-group-header"
       [ngStyle]="getGroupHeaderStyle()">
       <ng-template
@@ -20,7 +20,7 @@ import { mouseEvent } from '../../events';
     </div>
     <ng-content 
       *ngIf="(groupHeader && groupHeader.template && expanded) || 
-             (!groupHeader || !groupHeader.template)">
+             (!groupHeader || !groupHeader.template || !row?.value)">
     </ng-content>
     <div
       *ngIf="rowDetail && rowDetail.template && expanded"

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -672,7 +672,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    * Returns if the row was expanded and set default row expansion when row expansion is empty
    */
   getRowExpanded(row: any): boolean {
-    if (this.rowExpansions.size === 0 && this.groupExpansionDefault) {
+    if (this.rowExpansions.size === 0 && this.groupExpansionDefault && this.groupedRows) {
       for (const group of this.groupedRows) {
         this.rowExpansions.set(group, 1);
       }

--- a/src/components/datatable.component.spec.ts
+++ b/src/components/datatable.component.spec.ts
@@ -185,4 +185,43 @@ describe('Datatable component', () => {
     });
   });
 
+
+  describe('table with row grouping', () => {
+    let fixture;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(DatatableComponent);
+      fixture.componentInstance.rows = [
+        { k: 'B', v: 1},
+        { k: 'A', v: 2},
+        { k: 'A', v: 1},
+        { k: 'B', v: 3},
+        { k: 'B', v: 2},
+      ];
+
+      fixture.componentInstance.columns = [
+        { prop: 'k' },
+        { prop: 'v' }
+      ];
+    });
+
+    it('should sort groups according to component rows order', () => {
+      fixture.componentInstance.groupRowsBy = 'k';
+      fixture.detectChanges();
+      
+      expect(fixture.componentInstance.groupedRows[0].key).toBe('B');
+      expect(fixture.componentInstance.groupedRows[1].key).toBe('A');
+    });
+
+    it('should sort group values according to component rows order', () => {
+      fixture.componentInstance.groupRowsBy = 'k';
+      fixture.detectChanges();
+      
+      expect(fixture.componentInstance.groupedRows[0].value).toEqual(
+        fixture.componentInstance.rows.filter(r => r.k === 'B'));
+      expect(fixture.componentInstance.groupedRows[1].value).toEqual(
+        fixture.componentInstance.rows.filter(r => r.k === 'A'));
+    });
+  });
+
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
#1064 Sorting has no effect when used with row grouping

Summary:
- `sorts` and column header sorting do not change the order of grouped rows in any way
- Once grouped, table rows cannot be ungrouped

**What is the new behavior?**
Grouping is applied to the sorted `internalRows` rather than the raw `rows` input so any changes to sorting can affect the order of groups and of rows within groups. 

Setting `groupRowsBy` to `null` will remove all row grouping. Care has been taken to allow the `ngx-datatable-group-header` markup shown in examples to not throw errors when rows are not grouped.

Rows are sorted lazily via accessors, so rapid changes to `sorts` and `groupRowsBy` may not incur as much overhead since they now just invalidate the sorted rows. Once sorted and grouped the rows are cached for subsequent access until invalidated.


**Does this PR introduce a breaking change?** (check one with "x")
- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

Tables with grouped rows for which sorting should not be allowed will need to set `externalSorting` to `true` as rows will now automatically sort in response to user interaction with the column headers. Perhaps someone noticed and wanted this behavior.

Setting the `groupRowsBy` input to `null` will *immediately* remove any information about grouped rows, including anything set by the `groupedRows` input. Previously, it may have been possible to set both `groupedRows` and `groupRowsBy` then remove the latter, retaining the original `groupedRows`. However, this seems like a strange use case.

**Other information**:
This addresses the question of how sorting should be handled when rows are grouped in only the most basic fashion. Grouped rows are always derived from the result of sorting the rows according to `sorts`. Therefore, changing the sort order of columns can change the order of groups since group order is determined by the position of the first row exhibiting that group trait. 

A few alternate sort methods when rows are grouped:
- Set `groupRowsBy = null` to disable row grouping when sorting on other columns (this PR makes this possible) so that the sort applies to all rows without groups.
- Set `externalSorting` when sorting on other columns and sort rows with respect to the groups.
- Set `externalSorting = true` and ignore sorting events to disable sorting