### PR TITLE
Row comparator

### DIFF
--- a/docs/api/column/inputs.md
+++ b/docs/api/column/inputs.md
@@ -23,8 +23,13 @@ The width of the column by default in pixels. Default value: `150`
 The column can be resized manually by the user. Default value: `true`
 
 ### `comparator`
-Custom sort comparator, used to apply custom sorting via client-side. See 
-[MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) for more info.
+Custom sort comparator, used to apply custom sorting via client-side.
+Function receives five parameters, namely values and rows of items to be sorted as well as direction of the sort ('asc'|'desc'):
+```
+(valueA, valueB, rowA, rowB, sortDirection) => -1|0|1
+```
+NOTE: Compare can be a standard JS comparison function (a,b) => -1|0|1 as additional parameters are silently ignored.
+See [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) for more info.
 
 ### `sortable`: `boolean`
 Sorting of the row values by this column. Default value: `true`

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -394,7 +394,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    *      return row.name !== 'Ethel Price';
    *    }
    */
-  @Input() displayCheck: (row, column?, value?) => boolean;
+  @Input() displayCheck: (row: any, column?: any, value?: any) => boolean;
 
   /**
    * A boolean you can use to set the detault behaviour of rows and groups

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -83,8 +83,8 @@ export function sortRows(rows: any[], columns: any[], dirs: SortPropDir[]): any[
       const propB = valueGetter(b, prop);
 
       const comparison = cachedDir.dir !== SortDirection.desc ?
-        cachedDir.compareFn(propA, propB, a, b) :
-        -cachedDir.compareFn(propA, propB, a, b);
+        cachedDir.compareFn(propA, propB, a, b, true) :
+        -cachedDir.compareFn(propA, propB, a, b, false);
 
       // Don't return 0 yet in case of needing to sort by next property
       if (comparison !== 0) return comparison;

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -83,8 +83,8 @@ export function sortRows(rows: any[], columns: any[], dirs: SortPropDir[]): any[
       const propB = valueGetter(b, prop);
 
       const comparison = cachedDir.dir !== SortDirection.desc ?
-        cachedDir.compareFn(propA, propB) :
-        -cachedDir.compareFn(propA, propB);
+        cachedDir.compareFn(propA, propB, a, b) :
+        -cachedDir.compareFn(propA, propB, a, b);
 
       // Don't return 0 yet in case of needing to sort by next property
       if (comparison !== 0) return comparison;

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -75,16 +75,25 @@ export function sortRows(rows: any[], columns: any[], dirs: SortPropDir[]): any[
     };
   });
 
-  return temp.sort(function(a: any, b: any) {
+  return temp.sort(function(rowA: any, rowB: any) {
 
     for(const cachedDir of cachedDirs) {
+      // Get property and valuegetters for column to be sorted
       const { prop, valueGetter } = cachedDir;
-      const propA = valueGetter(a, prop);
-      const propB = valueGetter(b, prop);
+      // Get A and B cell values from rows based on properties of the columns
+      const propA = valueGetter(rowA, prop);
+      const propB = valueGetter(rowB, prop);
 
+      // Compare function gets five parameters:
+      // Two cell values to be compared as propA and propB
+      // Two rows corresponding to the cells as rowA and rowB
+      // Direction of the sort for this column as SortDirection
+      // Compare can be a standard JS comparison function (a,b) => -1|0|1
+      // as additional parameters are silently ignored. The whole row and sort
+      // direction enable more complex sort logic.
       const comparison = cachedDir.dir !== SortDirection.desc ?
-        cachedDir.compareFn(propA, propB, a, b, true) :
-        -cachedDir.compareFn(propA, propB, a, b, false);
+        cachedDir.compareFn(propA, propB, rowA, rowB, cachedDir.dir) :
+        -cachedDir.compareFn(propA, propB, rowA, rowB, cachedDir.dir);
 
       // Don't return 0 yet in case of needing to sort by next property
       if (comparison !== 0) return comparison;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Column comparators get only the value of current cell. This prevents more complex comparators which would need to access to the whole row. This problem has been referred to in issue #817.


**What is the new behavior?**
The rows being compared are added as the 3rd and 4th parameters to the comparator function. This preserves backward compatibility as js functions silently ignore additional parameters. This PR resolves issue #817 with minimal changes.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
