### PR TITLE
Ngx pr

### DIFF
--- a/src/components/body/body-cell.component.ts
+++ b/src/components/body/body-cell.component.ts
@@ -7,7 +7,7 @@ import {
 import { Keys } from '../../utils';
 import { SortDirection } from '../../types';
 import { TableColumn } from '../../types/table-column.type';
-import { mouseEvent, keyboardEvent } from '../../events';
+import { MouseEvent, KeyboardEvent } from '../../events';
 
 @Component({
   selector: 'datatable-body-cell',

--- a/src/components/body/body-row-wrapper.component.ts
+++ b/src/components/body/body-row-wrapper.component.ts
@@ -2,7 +2,7 @@ import {
   Component, Input, Output, EventEmitter, HostListener, DoCheck,
   ChangeDetectionStrategy, KeyValueDiffer, ChangeDetectorRef, KeyValueDiffers
 } from '@angular/core';
-import { mouseEvent } from '../../events';
+import { MouseEvent } from '../../events';
 
 @Component({
   selector: 'datatable-row-wrapper',

--- a/src/components/body/body-row.component.ts
+++ b/src/components/body/body-row.component.ts
@@ -7,7 +7,7 @@ import {
   allColumnsByPinArr, columnsByPin, columnGroupWidths, columnsByPinArr, translateXY, Keys
 } from '../../utils';
 import { ScrollbarHelper } from '../../services';
-import { mouseEvent, keyboardEvent } from '../../events';
+import { MouseEvent, KeyboardEvent } from '../../events';
 
 @Component({
   selector: 'datatable-body-row',

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -5,7 +5,7 @@ import {
 import { translateXY, columnsByPin, columnGroupWidths, RowHeightCache } from '../../utils';
 import { SelectionType } from '../../types';
 import { ScrollerComponent } from './scroller.component';
-import { mouseEvent } from '../../events';
+import { MouseEvent } from '../../events';
 
 @Component({
   selector: 'datatable-body',

--- a/src/components/body/scroller.component.ts
+++ b/src/components/body/scroller.component.ts
@@ -3,7 +3,7 @@ import {
   OnInit, OnDestroy, HostBinding, ChangeDetectionStrategy
 } from '@angular/core';
 
-import { mouseEvent } from '../../events';
+import { MouseEvent } from '../../events';
 
 @Component({
   selector: 'datatable-scroller',

--- a/src/components/body/selection.component.ts
+++ b/src/components/body/selection.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
 import { Keys, selectRows, selectRowsBetween } from '../../utils';
 import { SelectionType } from '../../types';
-import { mouseEvent, keyboardEvent } from '../../events';
+import { MouseEvent, KeyboardEvent } from '../../events';
 
 export interface Model {
   type: string;

--- a/src/components/datatable.component.scss
+++ b/src/components/datatable.component.scss
@@ -83,6 +83,7 @@
    * Shared Styles
    */
   .datatable-body-row,
+  .datatable-row-center,
   .datatable-header-inner {
     display: -webkit-box;
     display: -moz-box;

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -17,7 +17,7 @@ import { DatatableGroupHeaderDirective } from './body/body-group-header.directiv
 import { DataTableColumnDirective } from './columns';
 import { DatatableRowDetailDirective } from './row-detail';
 import { DatatableFooterDirective } from './footer';
-import { mouseEvent } from '../events';
+import { MouseEvent } from '../events';
 
 @Component({
   selector: 'ngx-datatable',

--- a/src/components/header/header-cell.component.ts
+++ b/src/components/header/header-cell.component.ts
@@ -4,7 +4,7 @@ import {
 } from '@angular/core';
 import { SortDirection, SortType, SelectionType, TableColumn } from '../../types';
 import { nextSortDir } from '../../utils';
-import { mouseEvent } from '../../events';
+import { MouseEvent } from '../../events';
 
 @Component({
   selector: 'datatable-header-cell',

--- a/src/components/header/header.component.ts
+++ b/src/components/header/header.component.ts
@@ -4,7 +4,7 @@ import {
 import { SortType, SelectionType } from '../../types';
 import { columnsByPin, columnGroupWidths, columnsByPinArr, translateXY } from '../../utils';
 import { DataTableColumnDirective } from '../columns';
-import { mouseEvent } from '../../events';
+import { MouseEvent } from '../../events';
 
 @Component({
   selector: 'datatable-header',

--- a/src/directives/draggable.directive.ts
+++ b/src/directives/draggable.directive.ts
@@ -4,7 +4,7 @@ import {
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import 'rxjs/add/operator/takeUntil';
-import { mouseEvent } from '../events';
+import { MouseEvent } from '../events';
 
 /**
  * Draggable Directive for Angular2

--- a/src/directives/long-press.directive.ts
+++ b/src/directives/long-press.directive.ts
@@ -81,7 +81,7 @@ export class LongPressDirective implements OnDestroy {
     }
   }
 
-  loop(event: Event): void {
+  loop(event: MouseEvent): void {
     if (this.isLongPressing) {
       this.timeout = setTimeout(() => {
         this.longPressing.emit({

--- a/src/directives/resizeable.directive.ts
+++ b/src/directives/resizeable.directive.ts
@@ -3,7 +3,7 @@ import {
 } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
-import { mouseEvent } from '../events';
+import { MouseEvent } from '../events';
 import 'rxjs/add/operator/takeUntil';
 
 @Directive({

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,4 +1,5 @@
 declare let global: any;
 
-export const mouseEvent = (global as any).MouseEvent as MouseEvent;
-export const keyboardEvent = (global as any).KeyboardEvent as KeyboardEvent;
+/* tslint:disable:variable-name */
+export const MouseEvent = (global as any).MouseEvent as MouseEvent;
+export const KeyboardEvent = (global as any).KeyboardEvent as KeyboardEvent;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The naming of the exported events (mouseEvent and keyboardEvent) caused errors in our protractor tests. The naming of MouseEvent and KeyboardEvent used in the typings are unknown at runtime in the test causing an `Reference error: MouseEvent is not defined`, or `Reference error: KeyboardEvent is not defined`.

Also added a small css fix for datatable-row-center to fix a misalignment of headers on smaller screens. Screenshot attached.

![Screenshot](https://user-images.githubusercontent.com/2168580/32053158-be32de6e-ba5a-11e7-96b7-5b15f1c5fa16.png)


**What is the new behavior?**

The tests no longer produce undefined errors


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No