### PR TITLE
Rename datatable-row-* to datatable-column-*

### DIFF
--- a/src/components/body/body-row.component.ts
+++ b/src/components/body/body-row.component.ts
@@ -15,7 +15,7 @@ import { MouseEvent, KeyboardEvent } from '../../events';
   template: `
     <div
       *ngFor="let colGroup of columnsByPin; let i = index; trackBy: trackByGroups"
-      class="datatable-row-{{colGroup.type}} datatable-row-group"
+      class="datatable-column-{{colGroup.type}} datatable-column-group"
       [ngStyle]="stylesByGroup(colGroup.type)">
       <datatable-body-cell
         *ngFor="let column of colGroup.columns; let ii = index; trackBy: columnTrackingFn"

--- a/src/components/datatable.component.scss
+++ b/src/components/datatable.component.scss
@@ -83,15 +83,21 @@
    * Shared Styles
    */
   .datatable-body-row,
-  .datatable-row-center,
-  .datatable-header-inner {
+  .datatable-column-group {
     display: -webkit-box;
     display: -moz-box;
     display: -ms-flexbox;
     display: -webkit-flex;
     display: flex;
 
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -webkit-flex-direction: row;
+    -moz-box-orient: horizontal;
+    -moz-box-direction: normal;
+    -ms-flex-direction: row;
     flex-direction: row;
+    
     -webkit-flex-flow: row;
     -moz-flex-flow: row;
     -ms-flex-flow: row;
@@ -111,15 +117,12 @@
     }
   }
 
-  .datatable-row-left,
-  .datatable-row-right {
+  .datatable-column-left,
+  .datatable-column-right {
     z-index: 9;
   }
 
-  .datatable-row-left,
-  .datatable-row-center,
-  .datatable-row-group,
-  .datatable-row-right {
+  .datatable-column-group {
     position:relative;
   }
 
@@ -210,14 +213,6 @@
 
     .datatable-body-row {
       outline:none;
-
-      > div {
-        display: -webkit-box;
-        display: -moz-box;
-        display: -ms-flexbox;
-        display: -webkit-flex;
-        display: flex;
-      }
     }
   }
 

--- a/src/components/header/header.component.ts
+++ b/src/components/header/header.component.ts
@@ -17,7 +17,7 @@ import { MouseEvent } from '../../events';
      
       <div
         *ngFor="let colGroup of columnsByPin; trackBy: trackByGroups"
-        [class]="'datatable-row-' + colGroup.type"
+        class="datatable-column-{{colGroup.type}} datatable-column-group"
         [ngStyle]="stylesByGroup(colGroup.type)">
         <datatable-header-cell
           *ngFor="let column of colGroup.columns; trackBy: columnTrackingFn"

--- a/src/themes/material.scss
+++ b/src/themes/material.scss
@@ -13,19 +13,19 @@
   &.multi-click-selection {
     .datatable-body-row {
 			&.active,
-			&.active .datatable-row-group {
+			&.active .datatable-column-group {
 				background-color: #304FFE;
         color: #FFF;
 			}
 
 			&.active:hover,
-			&.active:hover .datatable-row-group {
+			&.active:hover .datatable-column-group {
 				background-color: #193AE4;
         color: #FFF;
 			}
 
 			&.active:focus,
-			&.active:focus .datatable-row-group {
+			&.active:focus .datatable-column-group {
 				background-color: #2041EF;
         color: #FFF;
 			}
@@ -35,7 +35,7 @@
   &:not(.cell-selection) {
     .datatable-body-row {
       &:hover,
-			&:hover .datatable-row-group {
+			&:hover .datatable-column-group {
 	      background-color: #eee;
 	      transition-property: background;
 	      transition-duration: .3s;
@@ -43,7 +43,7 @@
 	    }
 
 			&:focus,
-			&:focus .datatable-row-group {
+			&:focus .datatable-column-group {
 				background-color: #ddd;
 			}
     }
@@ -52,7 +52,7 @@
   &.cell-selection {
     .datatable-body-cell {
       &:hover,
-			&:hover .datatable-row-group {
+			&:hover .datatable-column-group {
 	      background-color: #eee;
 	      transition-property: background;
 	      transition-duration: .3s;
@@ -60,24 +60,24 @@
 	    }
 
 			&:focus,
-			&:focus .datatable-row-group {
+			&:focus .datatable-column-group {
 				background-color: #ddd;
 			}
 
 			&.active,
-			&.active .datatable-row-group {
+			&.active .datatable-column-group {
 				background-color: #304FFE;
         color: #FFF;
 			}
 
 			&.active:hover,
-			&.active:hover .datatable-row-group {
+			&.active:hover .datatable-column-group {
 				background-color: #193AE4;
         color: #FFF;
 			}
 
 			&.active:focus,
-			&.active:focus .datatable-row-group {
+			&.active:focus .datatable-column-group {
 				background-color: #2041EF;
         color: #FFF;
 			}
@@ -107,14 +107,14 @@
 	 */
 	 .datatable-header,
 	 .datatable-body {
-		 .datatable-row-left {
+		 .datatable-column-left {
 			background-color: #FFF;
 			background-position: 100% 0;
 			background-repeat: repeat-y;
 			background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAABCAYAAAD5PA/NAAAAFklEQVQIHWPSkNeSBmJhTQVtbiDNCgASagIIuJX8OgAAAABJRU5ErkJggg==);
 		}
 
-		.datatable-row-right {
+		.datatable-column-right {
 			background-position: 0 0;
 	    background-color: #fff;
 	    background-repeat: repeat-y;


### PR DESCRIPTION
Rename datatable-row-* to datatable-column-* that are column related and remove duplicated css

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`datatable-row-group` is used for column groups. 

**What is the new behavior?**

`datatable-column-group` is used for column groups. 
`datatable-row-group` should be reserved for expansions to row grouping. 

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No*

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

Anyone that takes a dependency on the undocumented style `datatable-row-group` will break.

**Other information**:
