### PR TITLE
fix TypeScript errors raised by import from '@swimlane/ngx-datatable/src'

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -205,10 +205,12 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    * based on the row heights cache for virtual scroll. Other scenarios
    * calculate scroll height automatically (as height will be undefined).
    */
-  get scrollHeight(): number {
+  get scrollHeight(): number | undefined {
     if (this.scrollbarV) {
       return this.rowHeightsCache.query(this.rowCount - 1);
     }
+    // avoid TS7030: Not all code paths return a value.
+    return undefined;
   }
 
   rowHeightsCache: RowHeightCache = new RowHeightCache();
@@ -234,7 +236,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    */
   constructor(private cd: ChangeDetectorRef) {
     // declare fn here so we can get access to the `this` property
-    this.rowTrackingFn = function(index: number, row: any): any {
+    this.rowTrackingFn = function(this: any, index: number, row: any): any {
       const idx = this.getRowIndex(row);
       if (this.trackByProp) {
         return `${idx}-${this.trackByProp}`;

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -744,9 +744,9 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   recalculateColumns(
     columns: any[] = this._internalColumns,
     forceIdx: number = -1,
-    allowBleed: boolean = this.scrollbarH): any[] {
+    allowBleed: boolean = this.scrollbarH): any[] | undefined {
 
-    if (!columns) return;
+    if (!columns) return undefined;
 
     let width = this.innerWidth;
     if (this.scrollbarV) {

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -3,7 +3,7 @@ import { getterForProp } from './column-prop-getters';
 /**
  * Gets the next sort direction
  */
-export function nextSortDir(sortType: SortType, current: SortDirection): SortDirection {
+export function nextSortDir(sortType: SortType, current: SortDirection): SortDirection | undefined {
   if (sortType === SortType.single) {
     if(current === SortDirection.asc) {
       return SortDirection.desc;
@@ -18,6 +18,8 @@ export function nextSortDir(sortType: SortType, current: SortDirection): SortDir
     } else if(current === SortDirection.desc) {
       return undefined;
     }
+    // avoid TS7030: Not all code paths return a value.
+    return undefined;
   }
 }
 

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -15,7 +15,7 @@ export function throttle(func: any, wait: number, options?: any) {
     result = func.apply(context, args);
   }
 
-  return function() {
+  return function(this: any) {
     const now = +new Date();
 
     if (!previous && options.leading === false) {


### PR DESCRIPTION
Fix critical TypeScript errors that prevent developers from working around AOT build problems by importing from `/src`.

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Using **ngx-datatable 11.0.1**
In the developer's project, change imports to import from '@swimlane/ngx-datatable/src'
Needed for issues such as:
https://github.com/swimlane/ngx-datatable/issues/1104#issuecomment-342528502
Do an aot build.
with angular-cli: `ng serve --aot`

> ERROR in node_modules/@swimlane/ngx-datatable/src/utils/throttle.ts(26,15): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
> node_modules/@swimlane/ngx-datatable/src/utils/sort.ts(6,74): error TS7030: Not all code paths return a value.
> node_modules/@swimlane/ngx-datatable/src/components/body/body.component.ts(208,23): error TS7030: Not all code paths return a value.
> node_modules/@swimlane/ngx-datatable/src/components/body/body.component.ts(238,19): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
> node_modules/@swimlane/ngx-datatable/src/components/body/body.component.ts(239,11): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
> node_modules/@swimlane/ngx-datatable/src/components/body/body.component.ts(240,26): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
> node_modules/@swimlane/ngx-datatable/src/components/datatable.component.ts(749,19): error TS7030: Not all code paths return a value.


**What is the new behavior?**

TypeScript only changes except for `return undefined;` instead of just `return;` or implicit return, which should be functionally equivalent.
Added `| undefined` for the return type of a few functions that could return `undefined`.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
