### PR TITLE
Workaround AOT issue with Angular 5

### DIFF
--- a/tsconfig-aot.json
+++ b/tsconfig-aot.json
@@ -40,6 +40,7 @@
   "angularCompilerOptions": {
     "genDir": "release/",
     "strictMetadataEmit": true,
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+	"annotationsAs": "decorators"
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Using ngx-datatable on Angular 5 AOT fails in the browser with Cannot read property 'subscribe' of undefined. See #1104 #1120 possibly #1114

**What is the new behavior?**

AOT builds no longer error in browser.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

The result of the tsconfig change will be that the compiled JS is not optimised to the extent that variables not set in the constructor are removed but presumably other optimisations will also be excluded. For example see \components\body\body.component.ts ln 216:

`rowHeightsCache: RowHeightCache = new RowHeightCache();` which isn't contained within the constructor. Technically perfectly valid but apparently stripped out by tsickle. See https://github.com/angular/angular/issues/19587 for more detail.

At some point in the future Angular will catch up with the version of TS and non constructor defaults will be once again supported at which point it would be best to revert this change.