### PR TITLE
Fix prefixer to not fail if vendor prefix not found

### DIFF
--- a/src/utils/prefixes.ts
+++ b/src/utils/prefixes.ts
@@ -7,8 +7,9 @@ const testStyle = typeof document !== 'undefined' ? document.createElement('div'
 // http://davidwalsh.name/vendor-prefix
 const prefix = function() {
   const styles = typeof window !== 'undefined' ? window.getComputedStyle(document.documentElement, '') : undefined;
-  const pre = typeof styles !== 'undefined'
-    ? (Array.prototype.slice.call(styles).join('').match(/-(moz|webkit|ms)-/))[1] : undefined;
+  const match = typeof styles !== 'undefined' ?
+    Array.prototype.slice.call(styles).join('').match(/-(moz|webkit|ms)-/) : null;
+  const pre = match !== null ? match[1] : undefined;
   const dom = typeof pre !== 'undefined' ? ('WebKit|Moz|MS|O').match(new RegExp('(' + pre + ')', 'i'))[1] : undefined;
 
   return dom ? {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
If document.documentElement styles don't have any vendor prefixed styles, you get a `trying to get 1 of null` error when prefix function tries to find the vendor prefix. This issue is unlikely to occur in a real browser but I could not get around it when running tests on components that use ngx-datatable in Jest, which uses JSDOM instead of a browser.

**What is the new behavior?**
Checks if match function returns null (prefix not found) before trying to get the prefix name.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
