### PR TITLE
Implement Stable Sorting Algorithm

### DIFF
--- a/src/components/datatable.component.spec.ts
+++ b/src/components/datatable.component.spec.ts
@@ -97,6 +97,71 @@ describe('Datatable component', () => {
       expect(fixture.componentInstance._internalRows[1]).toBe(initialRows[0]);
       expect(fixture.componentInstance._internalRows[2]).toBe(initialRows[1]);
     });
+
+    it('should use a stable sorting algorithm', () => {
+      const fixture = TestBed.createComponent(DatatableComponent);
+      /**
+       * the following `initialRows`, when sorted by the character length
+       * of the value of the `name` property would result in the following
+       * (unstable sort) in Chrome:
+       *  [
+       *    { name: 'cat' },
+       *    { name: 'sed' },
+       *    { name: 'man' },
+       *    { name: 'foo' },
+       *    { name: 'bar' },
+       *    { name: 'sit' },
+       *    { name: 'amet' },
+       *    { name: 'dolor' },
+       *    { name: 'ipsum' },
+       *    { name: 'lorem' },
+       *    { name: 'maecennas' }
+       *  ]
+       */
+      const initialRows = [
+        { name: 'sed' },
+        { name: 'dolor' },
+        { name: 'ipsum' },
+        { name: 'foo' },
+        { name: 'bar' },
+        { name: 'cat' },
+        { name: 'sit' },
+        { name: 'man' },
+        { name: 'lorem' },
+        { name: 'amet' },
+        { name: 'maecennas' }
+      ];
+
+      const columns = [
+        {
+          prop: 'name',
+          comparator: (nameA: string, nameB: string) => {
+            return nameA.length - nameB.length;
+          }
+        }
+      ];
+
+      fixture.componentInstance.rows = initialRows;
+      fixture.componentInstance.columns = columns;
+
+      fixture.detectChanges();
+
+      fixture.componentInstance.onColumnSort({
+        sorts: [{prop: 'name', dir: 'asc'}]
+      });
+
+      expect(fixture.componentInstance._internalRows[0]).toBe(initialRows[0]);
+      expect(fixture.componentInstance._internalRows[1]).toBe(initialRows[3]);
+      expect(fixture.componentInstance._internalRows[2]).toBe(initialRows[4]);
+      expect(fixture.componentInstance._internalRows[3]).toBe(initialRows[5]);
+      expect(fixture.componentInstance._internalRows[4]).toBe(initialRows[6]);
+      expect(fixture.componentInstance._internalRows[5]).toBe(initialRows[7]);
+      expect(fixture.componentInstance._internalRows[6]).toBe(initialRows[9]);
+      expect(fixture.componentInstance._internalRows[7]).toBe(initialRows[1]);
+      expect(fixture.componentInstance._internalRows[8]).toBe(initialRows[2]);
+      expect(fixture.componentInstance._internalRows[9]).toBe(initialRows[8]);
+      expect(fixture.componentInstance._internalRows[10]).toBe(initialRows[10]);
+    });
   });
 
   describe('When the column is sorted with a custom comparator', () => {

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -57,6 +57,12 @@ export function sortRows(rows: any[], columns: any[], dirs: SortPropDir[]): any[
   if(!rows) return [];
   if(!dirs || !dirs.length || !columns) return [...rows];
 
+  /**
+   * create a mapping from each row to its row index prior to sorting
+   */
+  const rowToIndexMap = new Map<any, number>();
+  rows.forEach((row, index) => rowToIndexMap.set(row, index));
+
   const temp = [...rows];
   const cols = columns.reduce((obj, col) => {
     if(col.comparator && typeof col.comparator === 'function') {
@@ -101,7 +107,9 @@ export function sortRows(rows: any[], columns: any[], dirs: SortPropDir[]): any[
       if (comparison !== 0) return comparison;
     }
 
-    // equal each other
-    return 0;
+    /**
+     * all else being equal, preserve original order of the rows (stable sort)
+     */
+    return rowToIndexMap.get(rowA) < rowToIndexMap.get(rowB) ? -1 : 1;
   });
 }


### PR DESCRIPTION
* Modify the datatable's sorting logic to implement stable sort.
  Add accompanying unit test.

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
ngx-datatable relies on each browser's native .sort() implementation, which
is not guaranteed to result in a stable sort in across all browsers.


**What is the new behavior?**
the ngx-datatable sorting implementation would result in a stable sort across
all browsers.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
