### PR TITLE
bug(sorting): Fix Stable Sorting Algorithm

### DIFF
--- a/src/components/datatable.component.spec.ts
+++ b/src/components/datatable.component.spec.ts
@@ -100,44 +100,69 @@ describe('Datatable component', () => {
 
     it('should use a stable sorting algorithm', () => {
       const fixture = TestBed.createComponent(DatatableComponent);
+      const initialRows = [
+        { name: 'sed',        state: 'CA' }, // 0
+        { name: 'dolor',      state: 'NY' }, // 1
+        { name: 'ipsum',      state: 'NY' }, // 2
+        { name: 'foo',        state: 'CA' }, // 3
+        { name: 'bar',        state: 'CA' }, // 4
+        { name: 'cat',        state: 'CA' }, // 5
+        { name: 'sit',        state: 'CA' }, // 6
+        { name: 'man',        state: 'CA' }, // 7
+        { name: 'lorem',      state: 'NY' }, // 8
+        { name: 'amet',       state: 'NY' }, // 9
+        { name: 'maecennas',  state: 'NY' }  // 10
+      ];
+      
       /**
-       * the following `initialRows`, when sorted by the character length
-       * of the value of the `name` property would result in the following
-       * (unstable sort) in Chrome:
+       * assume the following sort operations take place on `initialRows`:
+       * 1) initialRows.sort(byLengthOfNameProperty) (Ascending)
+       * 2) initialRows.sort(byState)                (Descending)
+       * 
+       * in browsers that do not natively implement stable sort (such as Chrome),
+       * the result could be:
+       * 
        *  [
-       *    { name: 'cat' },
-       *    { name: 'sed' },
-       *    { name: 'man' },
-       *    { name: 'foo' },
-       *    { name: 'bar' },
-       *    { name: 'sit' },
-       *    { name: 'amet' },
-       *    { name: 'dolor' },
-       *    { name: 'ipsum' },
-       *    { name: 'lorem' },
-       *    { name: 'maecennas' }
+       *    { name: 'maecennas',  state: 'NY' },
+       *    { name: 'amet',       state: 'NY' },
+       *    { name: 'dolor',      state: 'NY' },
+       *    { name: 'ipsum',      state: 'NY' },
+       *    { name: 'lorem',      state: 'NY' },
+       *    { name: 'sed',        state: 'CA' },
+       *    { name: 'cat',        state: 'CA' },
+       *    { name: 'man',        state: 'CA' },
+       *    { name: 'foo',        state: 'CA' },
+       *    { name: 'bar',        state: 'CA' },
+       *    { name: 'sit',        state: 'CA' }
+       *  ]
+       * 
+       * in browsers that natively implement stable sort the result is guaranteed
+       * to be:
+       * 
+       *  [
+       *    { name: 'amet',       state: 'NY' },
+       *    { name: 'dolor',      state: 'NY' },
+       *    { name: 'ipsum',      state: 'NY' },
+       *    { name: 'lorem',      state: 'NY' },
+       *    { name: 'maecennas',  state: 'NY' },
+       *    { name: 'sed',        state: 'CA' },
+       *    { name: 'foo',        state: 'CA' },
+       *    { name: 'bar',        state: 'CA' },
+       *    { name: 'cat',        state: 'CA' },
+       *    { name: 'sit',        state: 'CA' },
+       *    { name: 'man',        state: 'CA' }
        *  ]
        */
-      const initialRows = [
-        { name: 'sed' },
-        { name: 'dolor' },
-        { name: 'ipsum' },
-        { name: 'foo' },
-        { name: 'bar' },
-        { name: 'cat' },
-        { name: 'sit' },
-        { name: 'man' },
-        { name: 'lorem' },
-        { name: 'amet' },
-        { name: 'maecennas' }
-      ];
-
+      
       const columns = [
         {
           prop: 'name',
           comparator: (nameA: string, nameB: string) => {
             return nameA.length - nameB.length;
           }
+        },
+        {
+          prop: 'state'
         }
       ];
 
@@ -150,17 +175,21 @@ describe('Datatable component', () => {
         sorts: [{prop: 'name', dir: 'asc'}]
       });
 
-      expect(fixture.componentInstance._internalRows[0]).toBe(initialRows[0]);
-      expect(fixture.componentInstance._internalRows[1]).toBe(initialRows[3]);
-      expect(fixture.componentInstance._internalRows[2]).toBe(initialRows[4]);
-      expect(fixture.componentInstance._internalRows[3]).toBe(initialRows[5]);
-      expect(fixture.componentInstance._internalRows[4]).toBe(initialRows[6]);
-      expect(fixture.componentInstance._internalRows[5]).toBe(initialRows[7]);
-      expect(fixture.componentInstance._internalRows[6]).toBe(initialRows[9]);
-      expect(fixture.componentInstance._internalRows[7]).toBe(initialRows[1]);
-      expect(fixture.componentInstance._internalRows[8]).toBe(initialRows[2]);
-      expect(fixture.componentInstance._internalRows[9]).toBe(initialRows[8]);
-      expect(fixture.componentInstance._internalRows[10]).toBe(initialRows[10]);
+      fixture.componentInstance.onColumnSort({
+        sorts: [{prop: 'state', dir: 'desc'}]
+      });
+
+      expect(fixture.componentInstance._internalRows[0]).toBe(initialRows[9]);
+      expect(fixture.componentInstance._internalRows[1]).toBe(initialRows[1]);
+      expect(fixture.componentInstance._internalRows[2]).toBe(initialRows[2]);
+      expect(fixture.componentInstance._internalRows[3]).toBe(initialRows[8]);
+      expect(fixture.componentInstance._internalRows[4]).toBe(initialRows[10]);
+      expect(fixture.componentInstance._internalRows[5]).toBe(initialRows[0]);
+      expect(fixture.componentInstance._internalRows[6]).toBe(initialRows[3]);
+      expect(fixture.componentInstance._internalRows[7]).toBe(initialRows[4]);
+      expect(fixture.componentInstance._internalRows[8]).toBe(initialRows[5]);
+      expect(fixture.componentInstance._internalRows[9]).toBe(initialRows[6]);
+      expect(fixture.componentInstance._internalRows[10]).toBe(initialRows[7]);
     });
   });
 

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -116,7 +116,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
 
     // auto sort on new updates
     if (!this.externalSorting) {
-      this._internalRows = sortRows(val, this._internalColumns, this.sorts);
+      this._internalRows = sortRows(val, this._internalColumns, this.sorts, []);
     } else {
       this._internalRows = [...val];
     }
@@ -664,7 +664,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    */
   ngAfterViewInit(): void {
     if (!this.externalSorting) {
-      this._internalRows = sortRows(this._rows, this._internalColumns, this.sorts);
+      this._internalRows = sortRows(this._rows, this._internalColumns, this.sorts, this._internalRows);
     }
 
     // this has to be done to prevent the change detection
@@ -743,7 +743,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   ngDoCheck(): void {
     if (this.rowDiffer.diff(this.rows)) {
       if (!this.externalSorting) {
-        this._internalRows = sortRows(this._rows, this._internalColumns, this.sorts);
+        this._internalRows = sortRows(this._rows, this._internalColumns, this.sorts, this._internalRows);
       } else {
         this._internalRows = [...this.rows];
       }
@@ -1005,7 +1005,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
     // the rows again on the 'push' detection...
     if (this.externalSorting === false) {
       // don't use normal setter so we don't resort
-      this._internalRows = sortRows(this.rows, this._internalColumns, sorts);
+      this._internalRows = sortRows(this.rows, this._internalColumns, sorts, this._internalRows);
     }
 
     this.sorts = sorts;

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -51,18 +51,22 @@ export function orderByComparator(a: any, b: any): number {
 }
 
 /**
- * Sorts the rows
+ * creates a shallow copy of the `rows` input and returns the sorted copy. this function
+ * does not sort the `rows` argument in place
  */
-export function sortRows(rows: any[], columns: any[], dirs: SortPropDir[]): any[] {
+export function sortRows(rows: any[], columns: any[], dirs: SortPropDir[], priorSortResult: any[]): any[] {
   if(!rows) return [];
   if(!dirs || !dirs.length || !columns) return [...rows];
 
   /**
-   * create a mapping from each row to its row index prior to sorting
+   * record the row ordering of results from prior sort operations (if applicable)
+   * this is necessary to guarantee stable sorting behavior 
    */
   const rowToIndexMap = new Map<any, number>();
-  rows.forEach((row, index) => rowToIndexMap.set(row, index));
-
+  if (Array.isArray(priorSortResult)) {
+    priorSortResult.forEach((row, index) => rowToIndexMap.set(row, index));
+  }
+  
   const temp = [...rows];
   const cols = columns.reduce((obj, col) => {
     if(col.comparator && typeof col.comparator === 'function') {
@@ -107,6 +111,8 @@ export function sortRows(rows: any[], columns: any[], dirs: SortPropDir[]): any[
       if (comparison !== 0) return comparison;
     }
 
+    if (!(rowToIndexMap.has(rowA) && rowToIndexMap.has(rowB))) return 0;
+    
     /**
      * all else being equal, preserve original order of the rows (stable sort)
      */


### PR DESCRIPTION
* Correct the original implementation of stable sorting by
  passing the result of prior sorting operations to `sortRows`

**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
A prior commit attempted to introduce stable sorting to ngx-datatable. However, there was a bug in the implementation such that stable sorting did not fully work.


**What is the new behavior?**
Sorting in ngx-datatable is guaranteed to be stable.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Austin,

My original PR to implement stable sorting was incomplete. My understanding was that `sortRows` was always invoked with an array of rows that represented the ordering of rows that would have resulted from any prior sort operations taking place on the table. However, I now see that `sortRows` is always invoked with the table's `this._rows` object, and `this._rows` is not never modified by any sorting operations. The table's `this._internalRows` object does represent the row ordering that results from sort operations, so I am now getting the correct row ordering from the `this._internalRows` object. This PR introduces a more robust unit-test as well as the fix. Thank you
