### PR TITLE
Virtual row works with state change

### DIFF
--- a/src/components/body/body-row.component.ts
+++ b/src/components/body/body-row.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, Input, HostBinding, ElementRef, Output, KeyValueDiffers, KeyValueDiffer,
+  Component, Input, HostBinding, ElementRef, Output, KeyValueDiffers, KeyValueDiffer, NgZone,
   EventEmitter, HostListener, ChangeDetectionStrategy, ChangeDetectorRef, DoCheck, SkipSelf
 } from '@angular/core';
 
@@ -30,7 +30,7 @@ import { MouseEvent, KeyboardEvent, Event } from '../../events';
         [displayCheck]="displayCheck"
         (activate)="onActivate($event, ii)">
       </datatable-body-cell>
-    </div>      
+    </div>
   `
 })
 export class DataTableBodyRowComponent implements DoCheck {
@@ -47,12 +47,12 @@ export class DataTableBodyRowComponent implements DoCheck {
   @Input() set innerWidth(val: number) {
     if (this._columns) {
       const colByPin = columnsByPin(this._columns);
-      this._columnGroupWidths = columnGroupWidths(colByPin, colByPin);  
+      this._columnGroupWidths = columnGroupWidths(colByPin, colByPin);
     }
 
     this._innerWidth = val;
     this.recalculateColumns();
-    this.buildStylesByGroup();    
+    this.buildStylesByGroup();
   }
 
   get innerWidth(): number {
@@ -61,7 +61,12 @@ export class DataTableBodyRowComponent implements DoCheck {
 
   @Input() expanded: boolean;
   @Input() rowClass: any;
-  @Input() row: any;
+  public row: any;
+  @Input('row') set rowSetter(val: any) {
+    this.zone.run(() => {
+      this.row = val;
+    });
+  }
   @Input() group: any;
   @Input() isSelected: boolean;
   @Input() rowIndex: number;
@@ -123,8 +128,9 @@ export class DataTableBodyRowComponent implements DoCheck {
   constructor(
       private differs: KeyValueDiffers,
       @SkipSelf() private scrollbarHelper: ScrollbarHelper,
-      private cd: ChangeDetectorRef, 
-      element: ElementRef) {
+      private cd: ChangeDetectorRef,
+      element: ElementRef,
+      private zone: NgZone) {
     this._element = element.nativeElement;
     this._rowDiffer = differs.find({}).create();
   }
@@ -134,7 +140,7 @@ export class DataTableBodyRowComponent implements DoCheck {
       this.cd.markForCheck();
     }
   }
-  
+
   trackByGroups(index: number, colGroup: any): any {
     return colGroup.type;
   }
@@ -215,7 +221,7 @@ export class DataTableBodyRowComponent implements DoCheck {
   recalculateColumns(val: any[] = this.columns): void {
     this._columns = val;
     const colsByPin = columnsByPin(this._columns);
-    this._columnsByPin = allColumnsByPinArr(this._columns);        
+    this._columnsByPin = allColumnsByPinArr(this._columns);
     this._columnGroupWidths = columnGroupWidths(colsByPin, this._columns);
   }
 

--- a/src/components/body/body-row.component.ts
+++ b/src/components/body/body-row.component.ts
@@ -20,7 +20,7 @@ import { MouseEvent, KeyboardEvent, Event } from '../../events';
       <datatable-body-cell
         *ngFor="let column of colGroup.columns; let ii = index; trackBy: columnTrackingFn"
         tabindex="-1"
-        [row]="row"
+        [row]="_row"
         [group]="group"
         [expanded]="expanded"
         [isSelected]="isSelected"
@@ -61,10 +61,9 @@ export class DataTableBodyRowComponent implements DoCheck {
 
   @Input() expanded: boolean;
   @Input() rowClass: any;
-  public row: any;
-  @Input('row') set rowSetter(val: any) {
+  @Input() set row(val: any) {
     this.zone.run(() => {
-      this.row = val;
+      this._row = val;
     });
   }
   @Input() group: any;
@@ -124,6 +123,7 @@ export class DataTableBodyRowComponent implements DoCheck {
   };
 
   private _rowDiffer: KeyValueDiffer<{}, {}>;
+  private _row: any;
 
   constructor(
       private differs: KeyValueDiffers,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Any event from a cell that changes a state of any row doesn't work on virtually rendered rows. 


**What is the new behavior?**
Even from virtually rendered rows any even can change a state of a row and it reflects.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
