### PR TITLE
Adding in explicit injections for a hybrid angular app

### DIFF
--- a/src/components/body/body-cell.component.ts
+++ b/src/components/body/body-cell.component.ts
@@ -1,7 +1,7 @@
 import {
   Component, Input, PipeTransform, HostBinding, ViewChild, ChangeDetectorRef,
   Output, EventEmitter, HostListener, ElementRef, ViewContainerRef, OnDestroy, DoCheck,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy, Inject
 } from '@angular/core';
 
 import { Keys } from '../../utils';
@@ -201,7 +201,7 @@ export class DataTableBodyCellComponent implements DoCheck, OnDestroy {
   private _expanded: boolean;
   private _element: any;
 
-  constructor(element: ElementRef, private cd: ChangeDetectorRef) {
+  constructor(@Inject(ElementRef) element: ElementRef, @Inject(ChangeDetectorRef) private cd: ChangeDetectorRef) {
     this._element = element.nativeElement;
   }
   

--- a/src/components/body/body-group-header-template.directive.ts
+++ b/src/components/body/body-group-header-template.directive.ts
@@ -1,8 +1,8 @@
-import { Directive, TemplateRef } from '@angular/core';
+import { Directive, TemplateRef, Inject } from '@angular/core';
 
 @Directive({
   selector: '[ngx-datatable-group-header-template]'
 })
 export class DatatableGroupHeaderTemplateDirective {
-  constructor(public template: TemplateRef<any>) { }
+  constructor(@Inject(TemplateRef) public template: TemplateRef<any>) { }
 }

--- a/src/components/body/body-row-wrapper.component.ts
+++ b/src/components/body/body-row-wrapper.component.ts
@@ -1,6 +1,6 @@
 import {
   Component, Input, Output, EventEmitter, HostListener, DoCheck,
-  ChangeDetectionStrategy, KeyValueDiffer, ChangeDetectorRef, KeyValueDiffers
+  ChangeDetectionStrategy, KeyValueDiffer, ChangeDetectorRef, KeyValueDiffers, Inject
 } from '@angular/core';
 import { MouseEvent } from '../../events';
 
@@ -86,7 +86,7 @@ export class DataTableRowWrapperComponent implements DoCheck {
   private _expanded: boolean = false;
   private _rowIndex: number;
   
-  constructor(private cd: ChangeDetectorRef, private differs: KeyValueDiffers) {
+  constructor(@Inject(ChangeDetectorRef) private cd: ChangeDetectorRef, @Inject(KeyValueDiffers) private differs: KeyValueDiffers) {
     this.rowDiffer = differs.find({}).create();
   }
 

--- a/src/components/body/body-row.component.ts
+++ b/src/components/body/body-row.component.ts
@@ -1,6 +1,6 @@
 import {
   Component, Input, HostBinding, ElementRef, Output, KeyValueDiffers, KeyValueDiffer,
-  EventEmitter, HostListener, ChangeDetectionStrategy, ChangeDetectorRef, DoCheck, SkipSelf
+  EventEmitter, HostListener, ChangeDetectionStrategy, ChangeDetectorRef, DoCheck, Inject
 } from '@angular/core';
 
 import {
@@ -121,10 +121,10 @@ export class DataTableBodyRowComponent implements DoCheck {
   private _rowDiffer: KeyValueDiffer<{}, {}>;
 
   constructor(
-      private differs: KeyValueDiffers,
-      @SkipSelf() private scrollbarHelper: ScrollbarHelper,
-      private cd: ChangeDetectorRef, 
-      element: ElementRef) {
+      @Inject(KeyValueDiffers) private differs: KeyValueDiffers,
+      @Inject(ScrollbarHelper) private scrollbarHelper: ScrollbarHelper,
+      @Inject(ChangeDetectorRef) private cd: ChangeDetectorRef, 
+      @Inject(ElementRef) element: ElementRef) {
     this._element = element.nativeElement;
     this._rowDiffer = differs.find({}).create();
   }

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -1,6 +1,6 @@
 import {
   Component, Output, EventEmitter, Input, HostBinding, ChangeDetectorRef,
-  ViewChild, OnInit, OnDestroy, ChangeDetectionStrategy
+  ViewChild, OnInit, OnDestroy, ChangeDetectionStrategy, Inject
 } from '@angular/core';
 import { translateXY, columnsByPin, columnGroupWidths, RowHeightCache } from '../../utils';
 import { SelectionType } from '../../types';
@@ -235,7 +235,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   /**
    * Creates an instance of DataTableBodyComponent.
    */
-  constructor(private cd: ChangeDetectorRef) {
+  constructor(@Inject(ChangeDetectorRef) private cd: ChangeDetectorRef) {
     // declare fn here so we can get access to the `this` property
     this.rowTrackingFn = function(this: any, index: number, row: any): any {
       const idx = this.getRowIndex(row);

--- a/src/components/body/scroller.component.ts
+++ b/src/components/body/scroller.component.ts
@@ -1,6 +1,6 @@
 import {
   Component, Input, ElementRef, Output, EventEmitter, Renderer2, NgZone,
-  OnInit, OnDestroy, HostBinding, ChangeDetectionStrategy
+  OnInit, OnDestroy, HostBinding, ChangeDetectionStrategy, Inject
 } from '@angular/core';
 
 import { MouseEvent } from '../../events';
@@ -36,7 +36,11 @@ export class ScrollerComponent implements OnInit, OnDestroy {
   parentElement: any;
   onScrollListener: any;
 
-  constructor(private ngZone: NgZone, element: ElementRef, private renderer: Renderer2) {
+  constructor(
+    @Inject(NgZone) private ngZone: NgZone,
+    @Inject(ElementRef) element: ElementRef,
+    @Inject(Renderer2) private renderer: Renderer2
+  ) {
 
     this.element = element.nativeElement;
   }

--- a/src/components/columns/column-cell.directive.ts
+++ b/src/components/columns/column-cell.directive.ts
@@ -1,6 +1,6 @@
-import { Directive, TemplateRef } from '@angular/core';
+import { Directive, TemplateRef, Inject } from '@angular/core';
 
 @Directive({ selector: '[ngx-datatable-cell-template]' })
 export class DataTableColumnCellDirective {
-  constructor(public template: TemplateRef<any>) { }
+  constructor(@Inject(TemplateRef) public template: TemplateRef<any>) { }
 }

--- a/src/components/columns/column-header.directive.ts
+++ b/src/components/columns/column-header.directive.ts
@@ -1,6 +1,6 @@
-import { Directive, TemplateRef } from '@angular/core';
+import { Directive, TemplateRef, Inject } from '@angular/core';
 
 @Directive({ selector: '[ngx-datatable-header-template]' })
 export class DataTableColumnHeaderDirective {
-  constructor(public template: TemplateRef<any>) { }
+  constructor(@Inject(TemplateRef) public template: TemplateRef<any>) { }
 }

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -3,7 +3,7 @@ import {
   HostListener, ContentChildren, OnInit, QueryList, AfterViewInit,
   HostBinding, ContentChild, TemplateRef, IterableDiffer,
   DoCheck, KeyValueDiffers, KeyValueDiffer, ViewEncapsulation,
-  ChangeDetectionStrategy, ChangeDetectorRef, SkipSelf
+  ChangeDetectionStrategy, ChangeDetectorRef, Inject
 } from '@angular/core';
 
 import {
@@ -645,11 +645,11 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   _columnTemplates: QueryList<DataTableColumnDirective>;
 
   constructor(
-    @SkipSelf() private scrollbarHelper: ScrollbarHelper,
-    @SkipSelf() private dimensionsHelper: DimensionsHelper,
-    private cd: ChangeDetectorRef,
-    element: ElementRef,
-    differs: KeyValueDiffers) {
+    @Inject(ScrollbarHelper) private scrollbarHelper: ScrollbarHelper,
+    @Inject(DimensionsHelper) private dimensionsHelper: DimensionsHelper,
+    @Inject(ChangeDetectorRef) private cd: ChangeDetectorRef,
+    @Inject(ElementRef) element: ElementRef,
+    @Inject(KeyValueDiffers) differs: KeyValueDiffers) {
 
     // get ref to elm for measuring
     this.element = element.nativeElement;

--- a/src/components/footer/footer-template.directive.ts
+++ b/src/components/footer/footer-template.directive.ts
@@ -1,6 +1,6 @@
-import { Directive, TemplateRef } from '@angular/core';
+import { Directive, TemplateRef, Inject } from '@angular/core';
 
 @Directive({ selector: '[ngx-datatable-footer-template]' })
 export class DataTableFooterTemplateDirective {
-  constructor(public template: TemplateRef<any>) { }
+  constructor(@Inject(TemplateRef) public template: TemplateRef<any>) { }
 }

--- a/src/components/header/header-cell.component.ts
+++ b/src/components/header/header-cell.component.ts
@@ -1,6 +1,6 @@
 import {
   Component, Input, EventEmitter, Output, HostBinding, 
-  HostListener, ChangeDetectionStrategy, ChangeDetectorRef
+  HostListener, ChangeDetectionStrategy, ChangeDetectorRef, Inject
 } from '@angular/core';
 import { SortDirection, SortType, SelectionType, TableColumn } from '../../types';
 import { nextSortDir } from '../../utils';
@@ -167,7 +167,7 @@ export class DataTableHeaderCellComponent {
   private _column: TableColumn;
   private _sorts: any[];
 
-  constructor(private cd: ChangeDetectorRef) { }
+  constructor(@Inject(ChangeDetectorRef) private cd: ChangeDetectorRef) { }
 
   @HostListener('contextmenu', ['$event'])
   onContextmenu($event: MouseEvent): void {

--- a/src/components/header/header.component.ts
+++ b/src/components/header/header.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, Output, EventEmitter, Input, HostBinding, ChangeDetectorRef, ChangeDetectionStrategy
+  Component, Output, EventEmitter, Input, HostBinding, ChangeDetectorRef, ChangeDetectionStrategy, Inject
 } from '@angular/core';
 import { SortType, SelectionType } from '../../types';
 import { columnsByPin, columnGroupWidths, columnsByPinArr, translateXY } from '../../utils';
@@ -132,7 +132,7 @@ export class DataTableHeaderComponent {
     right: {}
   };
 
-  constructor(private cd: ChangeDetectorRef) { }
+  constructor(@Inject(ChangeDetectorRef) private cd: ChangeDetectorRef) { }
 
   onLongPressStart({ event, model }: { event: any, model: any }) {
     model.dragging = true;

--- a/src/components/row-detail/row-detail-template.directive.ts
+++ b/src/components/row-detail/row-detail-template.directive.ts
@@ -1,8 +1,8 @@
-import { Directive, TemplateRef } from '@angular/core';
+import { Directive, TemplateRef, Inject } from '@angular/core';
 
 @Directive({
   selector: '[ngx-datatable-row-detail-template]'
 })
 export class DatatableRowDetailTemplateDirective {
-  constructor(public template: TemplateRef<any>) { }
+  constructor(@Inject(TemplateRef) public template: TemplateRef<any>) { }
 }

--- a/src/directives/draggable.directive.ts
+++ b/src/directives/draggable.directive.ts
@@ -1,5 +1,5 @@
 import {
-  Directive, ElementRef, Input, Output, EventEmitter, OnDestroy, OnChanges, SimpleChanges
+  Directive, ElementRef, Input, Output, EventEmitter, OnDestroy, OnChanges, SimpleChanges, Inject
 } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
@@ -31,7 +31,7 @@ export class DraggableDirective implements OnDestroy, OnChanges {
   isDragging: boolean = false;
   subscription: Subscription;
 
-  constructor(element: ElementRef) {
+  constructor(@Inject(ElementRef) element: ElementRef) {
     this.element = element.nativeElement;
   }
 

--- a/src/directives/orderable.directive.ts
+++ b/src/directives/orderable.directive.ts
@@ -16,7 +16,7 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
   positions: any;
   differ: any;
 
-  constructor(differs: KeyValueDiffers, @Inject(DOCUMENT) private document: any) {
+  constructor(@Inject(KeyValueDiffers) differs: KeyValueDiffers, @Inject(DOCUMENT) private document: any) {
     this.differ = differs.find({}).create();
   }
 

--- a/src/directives/resizeable.directive.ts
+++ b/src/directives/resizeable.directive.ts
@@ -1,5 +1,5 @@
 import {
-  Directive, ElementRef, HostListener, Input, Output, EventEmitter, OnDestroy, AfterViewInit, Renderer2
+  Directive, ElementRef, HostListener, Input, Output, EventEmitter, OnDestroy, AfterViewInit, Renderer2, Inject
 } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
@@ -25,7 +25,7 @@ export class ResizeableDirective implements OnDestroy, AfterViewInit {
   subscription: Subscription;
   resizing: boolean = false;
 
-  constructor(element: ElementRef, private renderer: Renderer2) {
+  constructor(@Inject(ElementRef) element: ElementRef, @Inject(Renderer2) private renderer: Renderer2) {
     this.element = element.nativeElement;
   }
 

--- a/src/directives/visibility.directive.ts
+++ b/src/directives/visibility.directive.ts
@@ -1,5 +1,5 @@
 import {
-  Directive, Output, EventEmitter, ElementRef, HostBinding, NgZone, OnInit, OnDestroy
+  Directive, Output, EventEmitter, ElementRef, HostBinding, NgZone, OnInit, OnDestroy, Inject
 } from '@angular/core';
 
 /**
@@ -23,7 +23,7 @@ export class VisibilityDirective implements OnInit, OnDestroy {
 
   timeout: any;
 
-  constructor(private element: ElementRef, private zone: NgZone) { }
+  constructor(@Inject(ElementRef) private element: ElementRef, @Inject(NgZone) private zone: NgZone) { }
 
   ngOnInit(): void {
     this.runCheck();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When running an [Angular Hybrid](https://github.com/ui-router/angular-hybrid/) app with both AngularJS 1.x and Angular 5 I get the error 

```Can't resolve all parameters for DataTableFooterTemplateDirective: (?)```


**What is the new behavior?**

Added in explicit injection so that angular can resolve all the parameters

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

This shouldn't change or affect anything, so there is no need to change any documentation or tests.