### PR TITLE
Fall back to view mode when select field value doesn't change

### DIFF
--- a/demo/basic/inline.component.ts
+++ b/demo/basic/inline.component.ts
@@ -48,6 +48,7 @@ import { Component } from '@angular/core';
             </span>
             <select
               *ngIf="editing[rowIndex + '-gender']"
+              (blur)="editing[rowIndex + '-gender'] = false"
               (change)="updateValue($event, 'gender', rowIndex)"
               [value]="value">
               <option value="male">Male</option>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When double clicking on a select field (but also text areas and probably other elements I am not aware), if the value is not changed, the field is stuck in the "edit" mode (it doesn't go back to show the span element). Adding the blur event, allows to fall back to the "view" mode (the select element is replaced by the span one) when the value is not changed.


**What is the new behavior?**
On blur the select element is hidden, replaced by the span element, going correctly back to the "view" mode.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
