### PR TITLE
fix: propagate sortDir changes to template

### DIFF
--- a/src/components/header/header-cell.component.ts
+++ b/src/components/header/header-cell.component.ts
@@ -79,6 +79,7 @@ export class DataTableHeaderCellComponent {
   @Input() set sorts(val: any[]) {
     this._sorts = val;
     this.sortDir = this.calcSortDir(val);
+    this.cellContext.sortDir = this.sortDir;
     this.sortClass = this.calcSortClass(this.sortDir);
     this.cd.markForCheck();
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The property sortDir of header DataTableHeaderCellComponent is not updated in the template after a sort is triggered. See last comments in #808 

**What is the new behavior?**
sortDir is propagated to cellcontext.sortdir and therefore updated when accessed via ngTemplateOutletContext inside templates


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
