### PR TITLE
Add setStylesByGroup() in set column prop

### DIFF
--- a/src/components/header/header.component.ts
+++ b/src/components/header/header.component.ts
@@ -101,6 +101,7 @@ export class DataTableHeaderComponent {
     const colsByPin = columnsByPin(val);
     this._columnsByPin = columnsByPinArr(val);
     this._columnGroupWidths = columnGroupWidths(colsByPin, val);
+    this.setStylesByGroup();
   }
 
   get columns(): any[] {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Column headers are not being resized on initialization
![image](https://user-images.githubusercontent.com/1208226/35054784-c6383732-fbad-11e7-9e7b-9fe5e200cfdb.png)

Without any changes to the code, only a windows resize seems to resolve this issue.

**What is the new behavior?**
It re-calculates the style (width) of each groups "left", "center", "right" after the columns have been set via the column property in `header.component.ts`.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No


**Other information**:
