### PR TITLE
Added tests accessing array elements through prop getter

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -25,6 +25,10 @@ module.exports =  function(config) {
       ChromeTravisCi: {
         base: 'Chrome',
         flags: ['--no-sandbox']
+      },
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
       }
     },
     coverageReporter: {

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -1,4 +1,5 @@
 const testWebpackConfig = require('./webpack.test');
+process.env.CHROME_BIN = require('puppeteer').executablePath()
 
 module.exports =  function(config) {
   var configuration = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-datatable",
-  "version": "11.1.5",
+  "version": "11.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -547,6 +547,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+      "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
     "asynckit": {
@@ -1623,6 +1629,17 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
+    },
     "connect": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.5.tgz",
@@ -2595,6 +2612,23 @@
       "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
       "dev": true
     },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "4.2.4"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+          "dev": true
+        }
+      }
+    },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
@@ -3075,6 +3109,35 @@
         "webpack-sources": "0.1.5"
       }
     },
+    "extract-zip": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
+      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.0",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -3149,6 +3212,15 @@
       "dev": true,
       "requires": {
         "websocket-driver": "0.7.0"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
+      "requires": {
+        "pend": "1.2.0"
       }
     },
     "file-loader": {
@@ -7684,6 +7756,12 @@
         "sha.js": "2.4.9"
       }
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -8306,6 +8384,12 @@
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
     "protractor": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.2.0.tgz",
@@ -8403,6 +8487,12 @@
         "ipaddr.js": "1.5.2"
       }
     },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
+    },
     "prr": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
@@ -8442,6 +8532,71 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
+    },
+    "puppeteer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.0.0.tgz",
+      "integrity": "sha512-e00NMdUL32YhBcua9OkVXHgyDEMBWJhDXkYNv0pyKRU1Z1OrsRm5zCpppAdxAsBI+/MJBspFNfOUZuZ24qPGMQ==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "extract-zip": "1.6.6",
+        "https-proxy-agent": "2.1.1",
+        "mime": "1.6.0",
+        "progress": "2.0.0",
+        "proxy-from-env": "1.0.0",
+        "rimraf": "2.6.2",
+        "ws": "3.3.3"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+          "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "5.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
+          "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
+          "dev": true,
+          "requires": {
+            "agent-base": "4.2.0",
+            "debug": "3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "ultron": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+          "dev": true
+        },
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "ultron": "1.1.1"
+          }
+        }
+      }
     },
     "q": {
       "version": "1.5.1",
@@ -10435,6 +10590,12 @@
         "mime-types": "2.1.17"
       }
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
     "typescript": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
@@ -11564,6 +11725,15 @@
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "dev": true,
+      "requires": {
+        "fd-slicer": "1.0.1"
       }
     },
     "yeast": {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "postcss": "^5.2.11",
     "postcss-loader": "^1.2.2",
     "protractor": "^5.2.0",
+    "puppeteer": "^1.0.0",
     "replace": "^0.3.0",
     "rimraf": "^2.6.2",
     "rxjs": "^5.5.2",

--- a/src/utils/column-prop-getters.spec.ts
+++ b/src/utils/column-prop-getters.spec.ts
@@ -50,4 +50,48 @@ describe('deepValueGetter', () => {
     expect(deepValueGetter(data, 'a.b.value')).toEqual(5);
   });
 
+  it('should get array-element two-level deep', () => {
+    let data = {
+      a: {
+        b: [
+          123
+        ]
+      }
+    };
+    expect(deepValueGetter(data, 'a.b.0')).toEqual(123);
+
+  });
+
+  it('should get value of object inside an array-element', () => {
+    let data = {
+      a: {
+        b: [
+          {c: 123}
+        ]
+      }
+    };
+    expect(deepValueGetter(data, 'a.b.0.c')).toEqual(123);
+  });
+   it('should get value of object inside a double array-element', () => {
+    let data = {
+      a: {
+        b: [
+          [
+            123
+          ]
+        ]
+      }
+    };
+    expect(deepValueGetter(data, 'a.b.0.0')).toEqual(123);
+  });
+  
+
+  it('should check for root-level fields with square brackets in name', () => {
+    let data = {
+      'a.b.1.value': 5
+    };
+    expect(deepValueGetter(data, 'a.b.1.value')).toEqual(5);
+  });
+
+
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x ] Other... Please describe: Added unit tests

**What is the current behavior?** (You can also link to an open issue here)
I could not find an info/example how to access array elements from a row object.
The obvious syntax to use square brackets did not work, therefore it seemed for me it does not work but after looking into code it occurred to me it's pretty trivial. I thought it's worth adding tests to show that.


**What is the new behavior?**
Added test cases showing access of array elements of a row object.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
At some point I was investigating getter from lodash (_.get), so that accessing array elements with square brackets like "a.b[3].value" could be possible - which is more intuitive for me. But that would introduce another dependency, and as it does a lot of regex it could perform not that well I suppose (didn't test the performance though).
Anyway, I stick with "a.b.3.value" syntax for now, and I wanted to share my investigation and add a specific test for the use case.