### PR TITLE
Added striped style to row-groups

### DIFF
--- a/release/themes/material.css
+++ b/release/themes/material.css
@@ -18,6 +18,8 @@
 	 */ }
   .ngx-datatable.material.striped .datatable-row-odd {
     background: #eee; }
+  .ngx-datatable.material.striped-row-group .datatable-body-row:nth-child(odd) {
+  background: #eee; }
   .ngx-datatable.material.single-selection .datatable-body-row.active,
   .ngx-datatable.material.single-selection .datatable-body-row.active .datatable-row-group, .ngx-datatable.material.multi-selection .datatable-body-row.active,
   .ngx-datatable.material.multi-selection .datatable-body-row.active .datatable-row-group, .ngx-datatable.material.multi-click-selection .datatable-body-row.active,


### PR DESCRIPTION
issue #1279. added striped style to row-groups

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
CSS class "striped" not working in row-grouping


**What is the new behavior?**
fixed by adding new class "striped-row-group" to material.css


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
