### PR TITLE
Changed page size calculation to count only fully visible rows

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -896,8 +896,20 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
     // This is because an expanded row is still considered to be a child of
     // the original row.  Hence calculation would use rowHeight only.
     if (this.scrollbarV) {
-      const size = Math.ceil(this.bodyHeight / this.rowHeight);
-      return Math.max(size, 0);
+        var height = this.bodyHeight;
+        if (this.scrollbarH) {
+          // Make sure height does not include horizontal scrollbar if visible
+          let bodyEl = this.element.querySelector('.datatable-body')
+          height = bodyEl.clientHeight;
+        }
+        // Page size should include only fully visible rows.
+        // If one row is not fitting fully in a given height, 
+        // it should be a first row on the next page.
+        var size = Math.floor(height / this.rowHeight);
+        
+        // Minimum page size is 1, in case when viewport is smaller than row's height. 
+        // To still make possible changing pages
+        return Math.max(size, 1);
     }
 
     // if limit is passed, we are paging


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Paging
-------
1. Calculation of the page size includes not fully visible row. If for example one pixel of a row is visible on a first page at the bottom, the next page would not contain it - it would be skipped.
2. Calculation of the page size does not take into account horizontal scrollbar height in a calculation. If for example a row is hidden behind a scrollbar, it will not be a part of the next page.
3. The minimum page size is 0, when the viewport is smaller than a row, paging is not available.



**What is the new behavior?**
Paging
-------
1. Calculation of the page size includes fully visible rows. If for example one pixel of a row is visible on a first page at the bottom, the row would be displayed as a first row on the next page. It would be also on the next page, if one pixel was missing to fully fit on the first page (!).
2. Calculation of the page size takes into account horizontal scrollbar height in a calculation. If for example a row is hidden behind a scrollbar, it will be shown as the first row on the next page.
3. The minimum page size is 1. When the viewport is smaller than a row, paging is still available - user change pages, which will show top parts of the rows.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Paging behavior is being changed here, so if someone did rely on previous behavior might be surprised after the change.