### PR TITLE
Fix Default Sort Behavior Of Table With Custom Templates

### DIFF
--- a/src/components/datatable.component.spec.ts
+++ b/src/components/datatable.component.spec.ts
@@ -10,11 +10,11 @@ import {
 } from '.';
 import { NgxDatatableModule } from '../datatable.module';
 
-let fixture: ComponentFixture<TestFixtureComponent>;
-let component: TestFixtureComponent;
+let fixture: ComponentFixture<any>;
+let component: any;
 
 describe('DatatableComponent', () => {
-  beforeEach(async(setupTest));
+  beforeEach(async(() => setupTest(TestFixtureComponent)));
 
   it('should sort date values', () => {
     const initialRows = [
@@ -365,27 +365,75 @@ describe('DatatableComponent', () => {
   });
 });
 
+describe('DatatableComponent With Custom Templates', () => {
+  beforeEach(async(() => setupTest(TestFixtureComponentWithCustomTemplates)));
+  
+  it('should sort when the table is initially rendered if `sorts` are provided', () => {
+    const initialRows = [
+      { id: 5  },
+      { id: 20 },
+      { id: 12 }
+    ];
+    
+    const sorts = [
+      {
+        prop: 'id',
+        dir: 'asc'
+      }
+    ];
+
+    component.rows = initialRows;
+    component.sorts = sorts;
+    fixture.detectChanges();
+
+    expect(textContent({ row: 1, column: 1 })).toContain('5', 'Ascending');
+    expect(textContent({ row: 2, column: 1 })).toContain('12', 'Ascending');
+    expect(textContent({ row: 3, column: 1 })).toContain('20', 'Ascending');
+  });
+});
+
 @Component({
   template: `
     <ngx-datatable
       [columns]="columns"
-      [rows]="rows">
+      [rows]="rows"
+      [sorts]="sorts">
     </ngx-datatable>
   `
 })
 class TestFixtureComponent {
   columns: any[] = [];
   rows: any[] = [];
+  sorts: any[] = [];
 }
 
-function setupTest() {
+@Component({
+  template: `
+    <ngx-datatable [rows]="rows" [sorts]="sorts">
+      <ngx-datatable-column name="Id" prop="id">
+        <ng-template let-column="column" ngx-datatable-header-template>
+          {{ column.name }}
+        </ng-template>
+        <ng-template let-row="row" ngx-datatable-cell-template>
+          {{ row.id }}
+        </ng-template>
+      </ngx-datatable-column>
+    </ngx-datatable>
+  `
+})
+class TestFixtureComponentWithCustomTemplates {
+  rows: any[] = [];
+  sorts: any[] = [];
+}
+
+function setupTest(componentClass) {
   return TestBed.configureTestingModule({
-    declarations: [ TestFixtureComponent ],
+    declarations: [ componentClass ],
     imports: [ NgxDatatableModule ]
   })
   .compileComponents()
   .then(() => {
-    fixture = TestBed.createComponent(TestFixtureComponent);
+    fixture = TestBed.createComponent(componentClass);
     component = fixture.componentInstance;
   });
 }

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -121,7 +121,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
     
     // auto sort on new updates
     if (!this.externalSorting) {
-      this._internalRows = sortRows(this._internalRows, this._internalColumns, this.sorts);
+      this.sortInternalRows();
     }
 
     // recalculate sizes/etc
@@ -673,7 +673,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    */
   ngAfterViewInit(): void {
     if (!this.externalSorting) {
-      this._internalRows = sortRows(this._internalRows, this._internalColumns, this.sorts);
+      this.sortInternalRows();
     }
 
     // this has to be done to prevent the change detection
@@ -716,6 +716,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
         this._internalColumns = translateTemplates(arr);
         setColumnDefaults(this._internalColumns);
         this.recalculateColumns();
+        this.sortInternalRows();
         this.cd.markForCheck();
       }
     }
@@ -756,7 +757,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   ngDoCheck(): void {
     if (this.rowDiffer.diff(this.rows)) {
       if (!this.externalSorting) {
-        this._internalRows = sortRows(this._internalRows, this._internalColumns, this.sorts);
+        this.sortInternalRows();
       } else {
         this._internalRows = [...this.rows];
       }
@@ -1012,16 +1013,15 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
       });
     }
 
-    const { sorts } = event;
+    this.sorts = event.sorts;
 
     // this could be optimized better since it will resort
     // the rows again on the 'push' detection...
     if (this.externalSorting === false) {
       // don't use normal setter so we don't resort
-      this._internalRows = sortRows(this._internalRows, this._internalColumns, sorts);
+      this.sortInternalRows();
     }
 
-    this.sorts = sorts;
     // Always go to first page when sorting to see the newly sorted data
     this.offset = 0;
     this.bodyComponent.updateOffsetY(this.offset);
@@ -1067,5 +1067,9 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    */
   onBodySelect(event: any): void {
     this.select.emit(event);
+  }
+  
+  private sortInternalRows(): void {
+    this._internalRows = sortRows(this._internalRows, this._internalColumns, this.sorts);
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
There are scenarios for which a table's `_internalColumns` object appears to be undefined when the initial sorting of the table occurs as a result of component lifecycle events. This can lead to the table not being sorted even when `sorts` are passed to the table via an input.


**What is the new behavior?**
Table rows are now sorted after changes to columnTemplates


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
