### PR TITLE
Fix link in column api docs

### DIFF
--- a/docs/api/column/inputs.md
+++ b/docs/api/column/inputs.md
@@ -7,7 +7,7 @@ Column label. If none specified, it will use the prop value and decamelize it.
 The property to bind the row values to. If `undefined`, it will camelcase the name value.
 
 ### `flexGrow`: `number`
-The grow factor relative to other columns. Same as the [flex-grow API](http =//www.w3.org/TR/css3-flexbox/). 
+The grow factor relative to other columns. Same as the [flex-grow API](https://www.w3.org/TR/css3-flexbox/). 
 It will any available extra width and distribute it proportionally according to all columns' flexGrow values. Default value: `0`
 
 ### `minWidth`: `number`


### PR DESCRIPTION
Fixed link in the column API docs to work with GitBook. Though the original appears to work on Github, it was generating an invalid link on GitBook.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Invalid link. 404


**What is the new behavior?**
Link now works correctly on GitBook.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
