### PR TITLE
reflect minWidh & maxWidth props to body cell

### DIFF
--- a/src/components/body/body-cell.component.ts
+++ b/src/components/body/body-cell.component.ts
@@ -165,6 +165,16 @@ export class DataTableBodyCellComponent implements DoCheck, OnDestroy {
     return this.column.width;
   }
 
+  @HostBinding('style.minWidth.px')
+  get minWidth(): number {
+    return this.column.minWidth;
+  }
+
+  @HostBinding('style.maxWidth.px')
+  get maxWidth(): number {
+    return this.column.maxWidth;
+  }
+
   @HostBinding('style.height')
   get height(): string | number {
     const height = this.rowHeight;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
minWidth and maxWidth properties are assigned only to header cells, which leads to multiple visual bugs issues.


**What is the new behavior?**
minWidth and maxWidth properties are also assigned to body cells.



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
related issue: #595 
