### PR TITLE
DataTableColumnDirective Input Binding Changes

### DIFF
--- a/src/components/columns/column.directive.spec.ts
+++ b/src/components/columns/column.directive.spec.ts
@@ -3,18 +3,20 @@ import { Component, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
 import { DataTableColumnDirective } from '.';
+import { ColumnChangesService } from '../../services/column-changes.service';
 
 @Component({
   selector: 'test-fixture-component',
   template: `
     <ngx-datatable-column id="t1"></ngx-datatable-column>
-    <ngx-datatable-column id="t2">
+    <ngx-datatable-column id="t2" [name]="columnName">
       <ng-template></ng-template>
       <ng-template></ng-template>
     </ngx-datatable-column>
   `
 })
 class TestFixtureComponent {
+  columnName: string;
 }
 
 describe('DataTableColumnDirective', () => {
@@ -28,6 +30,14 @@ describe('DataTableColumnDirective', () => {
       declarations: [ 
         DataTableColumnDirective,
         TestFixtureComponent
+      ],
+      providers: [
+        {
+          provide: ColumnChangesService,
+          useValue: {
+            onInputChange: jasmine.createSpy('onInputChange')
+          }
+        }
       ]
     });
   });
@@ -103,5 +113,23 @@ describe('DataTableColumnDirective', () => {
       expect(directive).toBeTruthy();
     });
 
+    it('should not notify of changes if its the first change', () => {
+      component.columnName = 'Column A';
+      fixture.detectChanges();
+      
+      expect(TestBed.get(ColumnChangesService).onInputChange).not.toHaveBeenCalled();
+    });
+
+    it('notifies of subsequent changes', () => {
+      component.columnName = 'Column A';
+      fixture.detectChanges();
+      
+      expect(TestBed.get(ColumnChangesService).onInputChange).not.toHaveBeenCalled();
+      
+      component.columnName = 'Column B';
+      fixture.detectChanges();
+      
+      expect(TestBed.get(ColumnChangesService).onInputChange).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/columns/column.directive.ts
+++ b/src/components/columns/column.directive.ts
@@ -1,11 +1,12 @@
-import { Directive, TemplateRef, ContentChild, Input } from '@angular/core';
+import { Directive, TemplateRef, ContentChild, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { DataTableColumnHeaderDirective } from './column-header.directive';
 import { DataTableColumnCellDirective } from './column-cell.directive';
 import { TableColumnProp } from '../../types';
+import { ColumnChangesService } from '../../services/column-changes.service';
 
 @Directive({ selector: 'ngx-datatable-column' })
-export class DataTableColumnDirective {
-
+export class DataTableColumnDirective implements OnChanges {
+  
   @Input() name: string;
   @Input() prop: TableColumnProp;
   @Input() frozenLeft: any;
@@ -35,4 +36,15 @@ export class DataTableColumnDirective {
   @ContentChild(DataTableColumnHeaderDirective, { read: TemplateRef })
   headerTemplate: TemplateRef<any>;
 
+  private isFirstChange = true;
+  
+  constructor(private columnChangesService: ColumnChangesService) {}
+  
+  ngOnChanges() {
+    if (this.isFirstChange) {
+      this.isFirstChange = false;
+    } else {
+      this.columnChangesService.onInputChange();
+    }
+  }
 }

--- a/src/components/datatable.component.spec.ts
+++ b/src/components/datatable.component.spec.ts
@@ -8,6 +8,7 @@ import {
   DataTableBodyRowComponent,
   DataTableBodyCellComponent
 } from '.';
+import { ColumnChangesService } from '../services/column-changes.service';
 import { NgxDatatableModule } from '../datatable.module';
 
 let fixture: ComponentFixture<any>;
@@ -370,7 +371,7 @@ describe('DatatableComponent With Custom Templates', () => {
   
   it('should sort when the table is initially rendered if `sorts` are provided', () => {
     const initialRows = [
-      { id: 5  },
+      { id: 5 },
       { id: 20 },
       { id: 12 }
     ];
@@ -389,6 +390,35 @@ describe('DatatableComponent With Custom Templates', () => {
     expect(textContent({ row: 1, column: 1 })).toContain('5', 'Ascending');
     expect(textContent({ row: 2, column: 1 })).toContain('12', 'Ascending');
     expect(textContent({ row: 3, column: 1 })).toContain('20', 'Ascending');
+  });
+
+  it('should reflect changes to input bindings of `ngx-datatable-column`', () => {
+    const initialRows = [
+      { id: 5, user: 'Sam', age: 35  },
+      { id: 20, user: 'Bob', age: 50 },
+      { id: 12, user: 'Joe', age: 60 }
+    ];
+
+    /**
+     * initially display `user` column as the second column in the table
+     */
+    component.rows = initialRows;
+    component.columnTwoProp = 'user';
+    fixture.detectChanges();
+
+    expect(textContent({ row: 1, column: 2 })).toContain('Sam', 'Displays user');
+    expect(textContent({ row: 2, column: 2 })).toContain('Bob', 'Displays user');
+    expect(textContent({ row: 3, column: 2 })).toContain('Joe', 'Displays user');
+    
+    /**
+     * switch to displaying `age` column as the second column in the table
+     */
+    component.columnTwoProp = 'age';
+    fixture.detectChanges();
+
+    expect(textContent({ row: 1, column: 2 })).toContain('35', 'Displays age');
+    expect(textContent({ row: 2, column: 2 })).toContain('50', 'Displays age');
+    expect(textContent({ row: 3, column: 2 })).toContain('60', 'Displays age');
   });
 });
 
@@ -418,18 +448,28 @@ class TestFixtureComponent {
           {{ row.id }}
         </ng-template>
       </ngx-datatable-column>
+      <ngx-datatable-column [prop]="columnTwoProp">
+        <ng-template let-column="column" ngx-datatable-header-template>
+          {{ column.name }}
+        </ng-template>
+        <ng-template let-row="row" let-column="column" ngx-datatable-cell-template>
+          {{ row[column.prop] }}
+        </ng-template>
+      </ngx-datatable-column>
     </ngx-datatable>
   `
 })
 class TestFixtureComponentWithCustomTemplates {
   rows: any[] = [];
   sorts: any[] = [];
+  columnTwoProp: string;
 }
 
 function setupTest(componentClass) {
   return TestBed.configureTestingModule({
     declarations: [ componentClass ],
-    imports: [ NgxDatatableModule ]
+    imports: [ NgxDatatableModule ],
+    providers: [ ColumnChangesService ]
   })
   .compileComponents()
   .then(() => {

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -3,14 +3,14 @@ import {
   HostListener, ContentChildren, OnInit, QueryList, AfterViewInit,
   HostBinding, ContentChild, TemplateRef, IterableDiffer,
   DoCheck, KeyValueDiffers, KeyValueDiffer, ViewEncapsulation,
-  ChangeDetectionStrategy, ChangeDetectorRef, SkipSelf
+  ChangeDetectionStrategy, ChangeDetectorRef, SkipSelf, OnDestroy
 } from '@angular/core';
 
 import {
   forceFillColumnWidths, adjustColumnWidths, sortRows,
   setColumnDefaults, throttleable, translateTemplates
 } from '../utils';
-import { ScrollbarHelper, DimensionsHelper } from '../services';
+import { ScrollbarHelper, DimensionsHelper, ColumnChangesService } from '../services';
 import { ColumnMode, SortType, SelectionType, TableColumn, ContextmenuType } from '../types';
 import { DataTableBodyComponent } from './body';
 import { DatatableGroupHeaderDirective } from './body/body-group-header.directive';
@@ -19,7 +19,7 @@ import { DatatableRowDetailDirective } from './row-detail';
 import { DatatableFooterDirective } from './footer';
 import { DataTableHeaderComponent } from './header';
 import { MouseEvent } from '../events';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 
 @Component({
   selector: 'ngx-datatable',
@@ -673,13 +673,15 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   _internalColumns: TableColumn[];
   _columns: TableColumn[];
   _columnTemplates: QueryList<DataTableColumnDirective>;
+  _subscriptions: Subscription[] = [];
 
   constructor(
     @SkipSelf() private scrollbarHelper: ScrollbarHelper,
     @SkipSelf() private dimensionsHelper: DimensionsHelper,
     private cd: ChangeDetectorRef,
     element: ElementRef,
-    differs: KeyValueDiffers) {
+    differs: KeyValueDiffers,
+    private columnChangesService: ColumnChangesService) {
 
     // get ref to elm for measuring
     this.element = element.nativeElement;
@@ -734,6 +736,8 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   ngAfterContentInit() {
     this.columnTemplates.changes.subscribe(v =>
       this.translateColumns(v));
+      
+    this.listenForColumnInputChanges();
   }
 
   /**
@@ -1113,6 +1117,24 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    */
   onBodySelect(event: any): void {
     this.select.emit(event);
+  }
+    
+  ngOnDestroy() {
+    this._subscriptions.forEach(subscription => subscription.unsubscribe());
+  }
+  
+  /**
+   * listen for changes to input bindings of all DataTableColumnDirective and
+   * trigger the columnTemplates.changes observable to emit
+   */
+  private listenForColumnInputChanges(): void {
+    this._subscriptions.push(this.columnChangesService
+      .columnInputChanges$
+      .subscribe(() => {
+        if (this.columnTemplates) {
+          this.columnTemplates.notifyOnChanges();
+        }
+      }));
   }
   
   private sortInternalRows(): void {

--- a/src/datatable.module.ts
+++ b/src/datatable.module.ts
@@ -36,7 +36,8 @@ import {
 
 import {
   ScrollbarHelper,
-  DimensionsHelper
+  DimensionsHelper,
+  ColumnChangesService
 } from './services';
 
 @NgModule({
@@ -45,7 +46,8 @@ import {
   ],
   providers: [
     ScrollbarHelper,
-    DimensionsHelper
+    DimensionsHelper,
+    ColumnChangesService
   ],
   declarations: [
     DataTableFooterTemplateDirective,

--- a/src/services/column-changes.service.ts
+++ b/src/services/column-changes.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+
+import { Observable, Subject } from 'rxjs';
+
+/**
+ * service to make DatatableComponent aware of changes to
+ * input bindings of DataTableColumnDirective
+ */
+@Injectable()
+export class ColumnChangesService {
+  private columnInputChanges = new Subject<undefined>();
+
+  get columnInputChanges$(): Observable<undefined> {
+    return this.columnInputChanges.asObservable();
+  }
+
+  onInputChange(): void {
+    this.columnInputChanges.next();
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,2 +1,3 @@
 export * from './scrollbar-helper.service';
 export * from './dimensions-helper.service';
+export * from './column-changes.service';


### PR DESCRIPTION
* Current Behavior: When creating a table using custom column
  templates via the DataTableColumnDirective, only the initial
  inputs to each DataTableColumnDirective are used to create
  column templates. Updating an input binding of
  DataTableColumnDirective after
  its creation does not result in updated column templates.
* Expected Behavior: This PR introduces a service that
  DataTableColumnDirectives use to communicate when changes to
  input bindings have occurred. DatatableComponent then subscribes
  to the service, and recreates column templates when the subscription
  emits.
* Resolves #1330

**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When creating a table using custom column
  templates via the DataTableColumnDirective, only the initial
  inputs to each DataTableColumnDirective are used to create
  column templates. Updating an input binding of
  DataTableColumnDirective after
  its creation does not result in updated column templates.


**What is the new behavior?**
This PR introduces a service that
  DataTableColumnDirectives use to communicate when changes to
  input bindings have occurred. DatatableComponent then subscribes
  to the service, and recreates column templates when the subscription
  emits.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
