### PR TITLE
Summary row fixes

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -7,11 +7,11 @@ module.exports =  function(config) {
     singleRun: true,
     frameworks: ['jasmine'],
     exclude: [],
-    files: [ 
-      { pattern: './config/spec-bundle.js', watched: false } 
+    files: [
+      { pattern: './config/spec-bundle.js', watched: false }
     ],
-    preprocessors: { 
-      './config/spec-bundle.js': ['coverage', 'webpack', 'sourcemap'] 
+    preprocessors: {
+      './config/spec-bundle.js': ['coverage', 'webpack', 'sourcemap']
     },
     webpack: testWebpackConfig({ env: 'test' }),
     webpackMiddleware: { stats: 'errors-only'},

--- a/demo/summary/summary-row-custom-template.component.ts
+++ b/demo/summary/summary-row-custom-template.component.ts
@@ -6,7 +6,7 @@ import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
     <div>
       <h3>Summary Row with Custom Template
         <small>
-        <a href="https://github.com/swimlane/ngx-datatable/blob/summary-row/demo/summary/summary-row-custom-template.component.ts">
+        <a href="https://github.com/swimlane/ngx-datatable/blob/master/demo/summary/summary-row-custom-template.component.ts">
           Source
         </a>
         </small>
@@ -14,7 +14,7 @@ import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
      <ngx-datatable
         class="material"
         [summaryRow]="true"
-        [summaryHeight]="100"
+        [summaryHeight]="'auto'"
         [columns]="columns"
         [columnMode]="'force'"
         [headerHeight]="50"

--- a/demo/summary/summary-row-inline-html.component.ts
+++ b/demo/summary/summary-row-inline-html.component.ts
@@ -4,9 +4,9 @@ import { Component } from '@angular/core';
   selector: 'summary-row-inline-html',
   template: `
     <div>
-      <h3>Simple Summary Row
+      <h3>Inline HTML template
         <small>
-        <a href="https://github.com/swimlane/ngx-datatable/blob/summary-row/demo/summary/summary-row-inline-html.component.ts">
+        <a href="https://github.com/swimlane/ngx-datatable/blob/master/demo/summary/summary-row-inline-html.component.ts">
           Source
         </a>
         </small>
@@ -15,6 +15,7 @@ import { Component } from '@angular/core';
         class="material"
         [summaryRow]="enableSummary"
         [summaryPosition]="summaryPosition"
+        [summaryHeight]="'auto'"
         [columnMode]="'force'"
         [headerHeight]="50"
         [rowHeight]="'auto'"

--- a/demo/summary/summary-row-server-paging.component.ts
+++ b/demo/summary/summary-row-server-paging.component.ts
@@ -14,7 +14,7 @@ import {Page} from '../paging/model/page';
       <h3>
         Server-side paging
         <small>
-          <a href="https://github.com/swimlane/ngx-datatable/blob/summary-row/demo/summary/summary-row-server-paging.component.ts">
+          <a href="https://github.com/swimlane/ngx-datatable/blob/master/demo/summary/summary-row-server-paging.component.ts">
             Source
           </a>
         </small>
@@ -26,6 +26,7 @@ import {Page} from '../paging/model/page';
         [columnMode]="'force'"
         [headerHeight]="50"
         [summaryRow]="true"
+        [summaryHeight]="'auto'"
         [footerHeight]="50"
         [rowHeight]="'auto'"
         [externalPaging]="true"

--- a/demo/summary/summary-row-simple.component.ts
+++ b/demo/summary/summary-row-simple.component.ts
@@ -48,7 +48,7 @@ export class SummaryRowSimpleComponent {
   rows = [];
 
   columns = [
-    { prop: 'name', summaryFunc: () => null },
+    { prop: 'name', summaryFunc: null, },
     { name: 'Gender', summaryFunc: (cells) => this.summaryForGender(cells) },
     { prop: 'age', summaryFunc: (cells) => this.avgAge(cells) },
   ];

--- a/demo/summary/summary-row-simple.component.ts
+++ b/demo/summary/summary-row-simple.component.ts
@@ -6,7 +6,7 @@ import { Component } from '@angular/core';
     <div>
       <h3>Simple Summary Row
         <small>
-        <a href="https://github.com/swimlane/ngx-datatable/blob/summary-row/demo/summary/summary-row-simple.component.ts">
+        <a href="https://github.com/swimlane/ngx-datatable/blob/master/demo/summary/summary-row-simple.component.ts">
           Source
         </a>
         </small>
@@ -32,6 +32,7 @@ import { Component } from '@angular/core';
         class="material"
         [summaryRow]="enableSummary"
         [summaryPosition]="summaryPosition"
+        [summaryHeight]="'auto'"
         [columns]="columns"
         [columnMode]="'force'"
         [headerHeight]="50"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "check": "npm-check --skip-unused",
     "test": "karma start",
+    "test-linux": "karma start --browsers ChromeTravisCi",
     "watch:test": "npm run test -- --auto-watch --no-single-run",
+    "watch:test-linux": "npm run test-linux -- --auto-watch --no-single-run",
     "lint": "tslint ./src/**/*.ts ./test/**/*.ts",
     "version": "npm run release",
     "preversion": "npm test",

--- a/src/components/body/body.component.spec.ts
+++ b/src/components/body/body.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, TestBed, ComponentFixture } from '@angular/core/testing';
+import {} from 'jasmine';
 
 import {
   DataTableBodyComponent,
@@ -94,5 +95,20 @@ describe('DataTableBodyComponent', () => {
       expect(component.indexes).toEqual(expectedIndexes);
     });
 
+  });
+
+  describe('Summary row', () => {
+    it('should not return custom styles for a bottom summary row if a scrollbar mode is off', () => {
+      const styles = component.getBottomSummaryRowStyles();
+      expect(styles).toBeFalsy();
+    });
+
+    it('should return custom styles for a bottom summary row if a scrollbar mode is on', () => {
+      component.rowHeight = 50;
+      component.scrollbarV = true;
+      component.rows = [ {num: 1}, {num: 2}, {num: 3}, {num: 4} ];
+      const styles = component.getBottomSummaryRowStyles();
+      expect(styles).toBeDefined();
+    });
   });
 });

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -86,6 +86,7 @@ import { MouseEvent } from '../../events';
         </datatable-row-wrapper>
         <datatable-summary-row
           *ngIf="summaryRow && summaryPosition === 'bottom'"
+          [ngStyle]="getBottomSummaryRowStyles()"
           [rowHeight]="summaryHeight"
           [offsetX]="offsetX"
           [innerWidth]="innerWidth"
@@ -512,6 +513,28 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
 
       translateXY(styles, 0, pos);
     }
+
+    return styles;
+  }
+
+  /**
+   * Calculate bottom summary row offset for scrollbar mode.
+   * For more information about cache and offset calculation
+   * see description for `getRowsStyles` method
+   *
+   * @returns {*} Returns the CSS3 style to be applied
+   *
+   * @memberOf DataTableBodyComponent
+   */
+  getBottomSummaryRowStyles(): any {
+    if (!this.scrollbarV || !this.rows || !this.rows.length) {
+      return null;
+    }
+
+    const styles = { position: 'absolute' };
+    const pos = this.rowHeightsCache.query(this.rows.length - 1);
+
+    translateXY(styles, 0, pos);
 
     return styles;
   }

--- a/src/components/body/summary/summary-row.component.spec.ts
+++ b/src/components/body/summary/summary-row.component.spec.ts
@@ -108,13 +108,15 @@ describe('DataTableSummaryRowComponent', () => {
         expect(component.summaryRow['col2']).toBeNull();
       });
 
-      it('should throw if there are non-number cells', () => {
+      it('should not compute a result if there are non-number cells', () => {
         component.rows = [
           { col1: 'aaa', col2: 'xxx' },
           { col1: 'bbb', col2: 34 },
         ];
 
-        expect(() => triggerChange()).toThrow();
+        triggerChange();
+        expect(component.summaryRow['col1']).toEqual(null);
+        expect(component.summaryRow['col2']).toEqual(null);
       });
     });
 

--- a/src/components/body/summary/summary-row.component.spec.ts
+++ b/src/components/body/summary/summary-row.component.spec.ts
@@ -95,6 +95,18 @@ describe('DataTableSummaryRowComponent', () => {
       expect(component.summaryRow['col2']).toEqual(rows[0]['col2'] + rows[1]['col2']);
     });
 
+    it('should works with default function and empty row', () => {
+      component.rows = [
+        { col1: null, col2: undefined },
+        { col1: null, },
+      ];
+
+      triggerChange();
+
+      expect(component.summaryRow['col1']).toBeNull();
+      expect(component.summaryRow['col2']).toBeNull();
+    });
+
     it('should use provided summary function', () => {
       const sum1 = 22;
       const sum2 = 'test sum';

--- a/src/components/body/summary/summary-row.component.spec.ts
+++ b/src/components/body/summary/summary-row.component.spec.ts
@@ -22,8 +22,8 @@ describe('DataTableSummaryRowComponent', () => {
 
   beforeEach(() => {
     rows = [
-      { col1: 'test', col2: 20 },
-      { col1: 'test1', col2: 30 },
+      { col1: 10, col2: 20 },
+      { col1: 1, col2: 30 },
     ];
     columns = [
       { prop: 'col1' }, { prop: 'col2' }
@@ -90,21 +90,40 @@ describe('DataTableSummaryRowComponent', () => {
       triggerChange();
     });
 
-    it('should use default sum function when no other provided', () => {
-      expect(component.summaryRow['col1']).toEqual(rows[0]['col1'] + rows[1]['col1']);
-      expect(component.summaryRow['col2']).toEqual(rows[0]['col2'] + rows[1]['col2']);
+    describe('Default Summary Function', () => {
+      it('should be used when no other provided', () => {
+        expect(component.summaryRow['col1']).toEqual(rows[0]['col1'] + rows[1]['col1']);
+        expect(component.summaryRow['col2']).toEqual(rows[0]['col2'] + rows[1]['col2']);
+      });
+
+      it('should works with empty row', () => {
+        component.rows = [
+          { col1: null, col2: undefined },
+          { col1: null, },
+        ];
+
+        triggerChange();
+
+        expect(component.summaryRow['col1']).toBeNull();
+        expect(component.summaryRow['col2']).toBeNull();
+      });
+
+      it('should throw if there are non-number cells', () => {
+        component.rows = [
+          { col1: 'aaa', col2: 'xxx' },
+          { col1: 'bbb', col2: 34 },
+        ];
+
+        expect(() => triggerChange()).toThrow();
+      });
     });
 
-    it('should works with default function and empty row', () => {
-      component.rows = [
-        { col1: null, col2: undefined },
-        { col1: null, },
-      ];
+    it('should not compute if null is set as a summary function', () => {
+      columns[0].summaryFunc = null;
 
       triggerChange();
 
-      expect(component.summaryRow['col1']).toBeNull();
-      expect(component.summaryRow['col2']).toBeNull();
+      expect(component.summaryRow['col1']).toEqual(null);
     });
 
     it('should use provided summary function', () => {

--- a/src/components/body/summary/summary-row.component.ts
+++ b/src/components/body/summary/summary-row.component.ts
@@ -9,9 +9,11 @@ export interface ISummaryColumn {
 }
 
 function defaultSumFunc(cells: any[]): any {
-  return cells
-    .filter(cell => !!cell)
-    .reduce((res, cell) => res + cell);
+  const cellsWithValues = cells.filter(cell => !!cell);
+
+  return cellsWithValues.length ?
+    cellsWithValues.reduce((res, cell) => res + cell) :
+    null;
 }
 
 @Component({

--- a/src/components/body/summary/summary-row.component.ts
+++ b/src/components/body/summary/summary-row.component.ts
@@ -15,8 +15,6 @@ function defaultSumFunc(cells: any[]): any {
     return null;
   }
   if (cellsWithValues.some(cell => typeof cell !== 'number')) {
-    throw new Error('Default summary function supports only numbers.' +
-      ' For other column types use a custom function.');
     return null;
   }
 

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -127,7 +127,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
     if (val) {
       this._internalRows = [...val];
     }
-    
+
     // auto sort on new updates
     if (!this.externalSorting) {
       this.sortInternalRows();
@@ -451,7 +451,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   /**
    * A height of summary row
    */
-  @Input() summaryHeight: number = this.rowHeight;
+  @Input() summaryHeight: number = 30;
 
   /**
    * A property holds a summary row position: top/bottom
@@ -1114,7 +1114,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   onBodySelect(event: any): void {
     this.select.emit(event);
   }
-  
+
   private sortInternalRows(): void {
     this._internalRows = sortRows(this._internalRows, this._internalColumns, this.sorts);
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
- [x] https://github.com/swimlane/ngx-datatable/issues/1412
- [x] https://github.com/swimlane/ngx-datatable/issues/1411
- [x] https://github.com/swimlane/ngx-datatable/issues/1417

**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
- [x] Yes
- [ ] No


**Other information**:
Breaking change notice: the default summary function will no longer work with columns with a type different than `number` - instead of string concatenation, there will be an empty cell.