### PR TITLE
Ability to use subrows

### DIFF
--- a/src/components/body/body-cell.component.ts
+++ b/src/components/body/body-cell.component.ts
@@ -139,7 +139,8 @@ export class DataTableBodyCellComponent implements DoCheck, OnDestroy {
           group: this.group, 
           column: this.column, 
           value: this.value ,
-          rowHeight: this.rowHeight
+          rowHeight: this.rowHeight,
+          expanded: this.expanded,
         });
 
         if (typeof res === 'string') {

--- a/src/datatable.module.ts
+++ b/src/datatable.module.ts
@@ -87,7 +87,8 @@ import {
     DataTableFooterTemplateDirective,
     DatatableFooterDirective,
     DataTablePagerComponent,
-    DatatableGroupHeaderTemplateDirective
+    DatatableGroupHeaderTemplateDirective,
+    DataTableBodyRowComponent
   ]
 })
 export class NgxDatatableModule { }


### PR DESCRIPTION
Following problem:

- I have historized records
- As default the latest version of each record shall be shown in the Datatable
- applying details to each of these "main rows" will open a details view with the other versions
- the other versions have the same attributes and shall be comparable with all other records
- so I'd like to use the current configuration / state of the table to render the subrows

`<ng-template let-row="row" let-expanded="expanded" ngx-datatable-row-detail-template>
	<div class="subrows">
		<datatable-body-row [columns]="getTableColumns()" [isSelected]='isSelected(subrow)' (activate)="onActivate($event, i, subrow)"
		*ngFor="let subrow of (getSubrows(row) | async); let i = index; trackBy: rowIdent" [row]="subrow" [innerWidth]="100" [offsetX]="0"
		[rowIndex]="i" [rowClass]="getSubrowClass"></datatable-body-row>
	</div>
</ng-template>`

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

It seems not to be possible to create subrows in details.

**What is the new behavior?**

Now I can create subrows in the details template

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No
... I don't think so

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
If PR accepted, I could create a demo if wished so