### PR TITLE
Fix usage withing prerendered SPA

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,6 +1,6 @@
 declare let global: any;
 
 /* tslint:disable:variable-name */
-export const MouseEvent = ((window as any) || (global as any)).MouseEvent as MouseEvent;
-export const KeyboardEvent = ((window as any) || (global as any)).KeyboardEvent as KeyboardEvent;
-export const Event = ((window as any) || (global as any)).Event as Event;
+export const MouseEvent = (((typeof window !== 'undefined' && window) as any) || (global as any)).MouseEvent as MouseEvent;
+export const KeyboardEvent = (((typeof window !== 'undefined' && window) as any) || (global as any)).KeyboardEvent as KeyboardEvent;
+export const Event = (((typeof window !== 'undefined' && window) as any) || (global as any)).Event as Event;


### PR DESCRIPTION
Make sure not to crash on the absence of a window object

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** 
Using ngx-datatable in the context of a prerendered application crashes as described in https://github.com/swimlane/ngx-datatable/issues/1396

**What is the new behavior?**
ngx-datatable can be used in a prerendered application without crashing.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information**:
