### PR TITLE
Virtual scroller sizing behavior is not responsive

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -154,8 +154,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
 
   @Input() set columns(val: any[]) {
     this._columns = val;
-    const colsByPin = columnsByPin(val);
-    this.columnGroupWidths = columnGroupWidths(colsByPin, val);
+    this.recalculateColumnWidths();
   }
 
   get columns(): any[] {
@@ -739,4 +738,11 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     return this.rowIndexes.get(row) || 0;
   }
 
+  /**
+   * Recalculates the column groups widths
+   */
+  recalculateColumnWidths(): void {
+    const colsByPin = columnsByPin(this.columns);
+    this.columnGroupWidths = columnGroupWidths(colsByPin, this.columns);
+  }
 }

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -815,6 +815,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   recalculate(): void {
     this.recalculateDims();
     this.recalculateColumns();
+    this.bodyComponent.recalculateColumnWidths();
   }
 
   /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Current the width of the virtual scroller is fixed at creation. This can result in strange behavior with the horizontal scroll when the window is resized for the "force" column mode. For example:

Minimum width of the columns is 600px. Table is initially rendered at 1000px width. The window is then resized so that the table has a width of 800px. If horizontal scrolling is enabled, the horizontal scroll bar will appear even though the columns have no hit their minimum width yet.


**What is the new behavior?**
I have added a method to recalculate the column widths used for the scroll width on the DataTableBodyComponent and added a call to this method to the DataTableComponent's recalculate method.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
