### PR TITLE
Virtual scroller sizing behavior is not responsive

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -28,7 +28,7 @@ import { MouseEvent } from '../../events';
         [scrollbarV]="scrollbarV"
         [scrollbarH]="scrollbarH"
         [scrollHeight]="scrollHeight"
-        [scrollWidth]="columnGroupWidths?.total"
+        [scrollWidth]="_columnGroupWidths?.total"
         (scroll)="onBodyScroll($event)">
         <datatable-summary-row
           *ngIf="summaryRow && summaryPosition === 'top'"
@@ -126,12 +126,23 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   @Input() rowClass: any;
   @Input() groupedRows: any;
   @Input() groupExpansionDefault: boolean;
-  @Input() innerWidth: number;
   @Input() groupRowsBy: string;
   @Input() virtualization: boolean;
   @Input() summaryRow: boolean;
   @Input() summaryPosition: string;
   @Input() summaryHeight: number;
+
+  @Input() set innerWidth(val: number) {
+    this._innerWidth = val;
+    if (this.columns) {
+      const colByPin = columnsByPin(this._columns);
+      this._columnGroupWidths = columnGroupWidths(colByPin, this._columns);
+    }
+  }
+
+  get innerWidth(): number {
+    return this._innerWidth;
+  }
 
   @Input() set pageSize(val: number) {
     this._pageSize = val;
@@ -154,8 +165,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
 
   @Input() set columns(val: any[]) {
     this._columns = val;
-    const colsByPin = columnsByPin(val);
-    this.columnGroupWidths = columnGroupWidths(colsByPin, val);
+    this.recalcLayout();
   }
 
   get columns(): any[] {
@@ -238,8 +248,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   temp: any[] = [];
   offsetY: number = 0;
   indexes: any = {};
-  columnGroupWidths: any;
-  columnGroupWidthsWithoutGroup: any;
+  _columnGroupWidths: any;
   rowTrackingFn: any;
   listener: any;
   rowIndexes: any = new Map();
@@ -251,6 +260,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   _rowCount: number;
   _offset: number;
   _pageSize: number;
+  _innerWidth: number;
 
   /**
    * Creates an instance of DataTableBodyComponent.
@@ -491,7 +501,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
 
     // only add styles for the group if there is a group
     if (this.groupedRows) {
-      styles['width'] = this.columnGroupWidths.total;
+      styles['width'] = this._columnGroupWidths.total;
     }
 
     if (this.scrollbarV) {
@@ -698,7 +708,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    * Gets the row pinning group styles
    */
   stylesByGroup(group: string) {
-    const widths = this.columnGroupWidths;
+    const widths = this._columnGroupWidths;
     const offsetX = this.offsetX;
 
     const styles = {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Current the width of the virtual scroller is fixed at creation. This can result in strange behavior with the horizontal scroll when the window is resized for the "force" column mode. For example:

Minimum width of the columns is 600px. Table is initially rendered at 1000px width. The window is then resized so that the table has a width of 800px. If horizontal scrolling is enabled, the horizontal scroll bar will appear even though the columns have no hit their minimum width yet.


**What is the new behavior?**
I've updated the DataTableBodyComponent to handle the sizing of the datatable-scroller element in the same manner that the DataTableHeaderComponent handles the sizing of its inner html element.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
