### PR TITLE
Fixed row groups header sizing

### DIFF
--- a/src/components/body/body-row-wrapper.component.ts
+++ b/src/components/body/body-row-wrapper.component.ts
@@ -108,7 +108,7 @@ export class DataTableRowWrapperComponent implements DoCheck {
 
     styles['transform'] = 'translate3d(' + this.offsetX + 'px, 0px, 0px)';
     styles['backface-visibility'] = 'hidden';
-    styles['width'] = this.innerWidth;
+    styles['width'] = this.innerWidth + 'px';
 
     return styles; 
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Currently, at least for me, row group headers are broken at display because the width of tag `ngx-datatable-group-header` is set to '0px'.

It looks like that if the size unit is not specified, many browsers set the width style to '0px', which is not what we expect.
I tested it with latest chrome and firefox on Ubuntu.

**What is the new behavior?**

Just append 'px' unit to the width, so all browsers are fine to display these headers.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
