### PR TITLE
datatable-row-wrapper: fix undefined reference access on group

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -46,10 +46,10 @@ import { MouseEvent } from '../../events';
           [rowDetail]="rowDetail"
           [groupHeader]="groupHeader"
           [offsetX]="offsetX"
-          [detailRowHeight]="getDetailRowHeight(group[i],i)"
+          [detailRowHeight]="!group ? 0 : getDetailRowHeight(group[i],i)"
           [row]="group"
           [expanded]="getRowExpanded(group)"
-          [rowIndex]="getRowIndex(group[i])"
+          [rowIndex]="!group ? -1 : getRowIndex(group[i])"
           (rowContextmenu)="rowContextmenu.emit($event)">
           <datatable-body-row
             *ngIf="!groupedRows; else groupedRowsTemplate"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
We are using a caching service that only keeps the data of the viewport in memory. Before and after the viewport the array is empty. If scrolling up into the empty area of the data array, we get an exception ("unable to get property '0' of undefined").


**What is the new behavior?**
No exception is thrown when scrolling up the table.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: -


**Other information**:
