### PR TITLE
Add _allColumns attribute to get all once added columns.

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -671,6 +671,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   _groupRowsBy: string;
   _internalRows: any[];
   _internalColumns: TableColumn[];
+  _allColumns: TableColumn[];
   _columns: TableColumn[];
   _columnTemplates: QueryList<DataTableColumnDirective>;
   _subscriptions: Subscription[] = [];
@@ -748,6 +749,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
       const arr = val.toArray();
       if (arr.length) {
         this._internalColumns = translateTemplates(arr);
+        this._allColumns = [...this._internalColumns];
         setColumnDefaults(this._internalColumns);
         this.recalculateColumns();
         this.sortInternalRows();


### PR DESCRIPTION
**What kind of change does this PR introduce?s ** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
We have only visible columns in _internalColumns

**What is the new behavior?**
After changing the set of columns you have always all once added columns in _allColumns attribute regardless whether they are hidden or not.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information**:
We need to be able to programmatically access all columns that have been defined in the template, regardless whether they are hidden or not.