### PR TITLE
Add canShowDataTable getter/setter to show/hide datatable element.

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -19,12 +19,12 @@ import { DatatableRowDetailDirective } from './row-detail';
 import { DatatableFooterDirective } from './footer';
 import { DataTableHeaderComponent } from './header';
 import { MouseEvent } from '../events';
-import { BehaviorSubject, Subscription } from 'rxjs';
+import { BehaviorSubject, Subscription, Observable } from 'rxjs';
 
 @Component({
   selector: 'ngx-datatable',
   template: `
-    <div
+    <div *ngIf="canShowDataTable | async"
       visibilityObserver
       (visible)="recalculate()">
       <datatable-header
@@ -655,6 +655,20 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
     return this.selected && this.rows &&
       this.rows.length !== 0 && allRowsSelected;
   }
+
+  /**
+   * Returns if datatable is set to shown.
+   */
+  get canShowDataTable(): Observable<boolean> {
+    return this._canShowDataTable.asObservable();
+  }
+  /**
+   * Set if datatable can be shown.
+   */
+  setCanShowDataTable(val: boolean): void {
+    return this._canShowDataTable.next(val);
+  }
+  private _canShowDataTable = new BehaviorSubject<boolean>(true);
 
   element: HTMLElement;
   _innerWidth: number;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The datatable container always visible


**What is the new behavior?**
Using canShowDataTable getter/setter we can show/hide datatable container


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information**:
It is very convenient to have some general functionality on the application to show/hide datatable container depends on some conditions without hiding full component and losing data or space which it occupies.