### PR TITLE
Fix issue with accessing data of async rows.

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -46,10 +46,10 @@ import { MouseEvent } from '../../events';
           [rowDetail]="rowDetail"
           [groupHeader]="groupHeader"
           [offsetX]="offsetX"
-          [detailRowHeight]="getDetailRowHeight(group[i],i)"
+          [detailRowHeight]="getDetailRowHeight(group && group[i],i)"
           [row]="group"
           [expanded]="getRowExpanded(group)"
-          [rowIndex]="getRowIndex(group[i])"
+          [rowIndex]="getRowIndex(group && group[i])"
           (rowContextmenu)="rowContextmenu.emit($event)">
           <datatable-body-row
             *ngIf="!groupedRows; else groupedRowsTemplate"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently, the template of body component is trying to access to `group[i]` without checking group and when data is coming async we are getting errors like this:
ERROR TypeError: Cannot read property '0' of undefined

**What is the new behavior?**
Check for 'group' variable and only after try to access the index of it.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No