### PR TITLE
Added property uid to column

### DIFF
--- a/docs/api/column/inputs.md
+++ b/docs/api/column/inputs.md
@@ -6,8 +6,11 @@ Column label. If none specified, it will use the prop value and decamelize it.
 ### `prop`: `string`
 The property to bind the row values to. If `undefined`, it will camelcase the name value.
 
+### `uid`: `string`
+Column uid. Default value: `undefined`
+
 ### `flexGrow`: `number`
-The grow factor relative to other columns. Same as the [flex-grow API](https://www.w3.org/TR/css3-flexbox/). 
+The grow factor relative to other columns. Same as the [flex-grow API](https://www.w3.org/TR/css3-flexbox/).
 It will any available extra width and distribute it proportionally according to all columns' flexGrow values. Default value: `0`
 
 ### `minWidth`: `number`

--- a/src/components/columns/column.directive.spec.ts
+++ b/src/components/columns/column.directive.spec.ts
@@ -27,7 +27,7 @@ describe('DataTableColumnDirective', () => {
   // provide our implementations or mocks to the dependency injector
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ 
+      declarations: [
         DataTableColumnDirective,
         TestFixtureComponent
       ],
@@ -52,7 +52,7 @@ describe('DataTableColumnDirective', () => {
 
   describe('fixture', () => {
     let directive: DataTableColumnDirective;
-    
+
     beforeEach(() => {
       directive = fixture.debugElement
         .query(By.directive(DataTableColumnDirective))
@@ -70,7 +70,7 @@ describe('DataTableColumnDirective', () => {
 
   describe('directive #1', () => {
     let directive: DataTableColumnDirective;
-    
+
     beforeEach(() => {
       directive = fixture.debugElement
         .query(By.css('#t1'))
@@ -85,6 +85,7 @@ describe('DataTableColumnDirective', () => {
       fixture.detectChanges();
       expect(directive.name).toBeUndefined();
       expect(directive.prop).toBeUndefined();
+      expect(directive.uid).toBeUndefined();
       expect(directive.frozenRight).toBeUndefined();
       expect(directive.frozenLeft).toBeUndefined();
       expect(directive.flexGrow).toBeUndefined();
@@ -103,7 +104,7 @@ describe('DataTableColumnDirective', () => {
 
   describe('directive #2', () => {
     let directive: DataTableColumnDirective;
-    
+
     beforeEach(() => {
       directive = fixture.debugElement
         .query(By.css('#t2'))
@@ -117,19 +118,19 @@ describe('DataTableColumnDirective', () => {
     it('should not notify of changes if its the first change', () => {
       component.columnName = 'Column A';
       fixture.detectChanges();
-      
+
       expect(TestBed.get(ColumnChangesService).onInputChange).not.toHaveBeenCalled();
     });
 
     it('notifies of subsequent changes', () => {
       component.columnName = 'Column A';
       fixture.detectChanges();
-      
+
       expect(TestBed.get(ColumnChangesService).onInputChange).not.toHaveBeenCalled();
-      
+
       component.columnName = 'Column B';
       fixture.detectChanges();
-      
+
       expect(TestBed.get(ColumnChangesService).onInputChange).toHaveBeenCalled();
     });
   });

--- a/src/components/columns/column.directive.ts
+++ b/src/components/columns/column.directive.ts
@@ -9,9 +9,10 @@ import { ColumnChangesService } from '../../services/column-changes.service';
 
 @Directive({ selector: 'ngx-datatable-column' })
 export class DataTableColumnDirective implements OnChanges {
-  
+
   @Input() name: string;
   @Input() prop: TableColumnProp;
+  @Input() uid: string;
   @Input() frozenLeft: any;
   @Input() frozenRight: any;
   @Input() flexGrow: number;
@@ -45,9 +46,9 @@ export class DataTableColumnDirective implements OnChanges {
   @ContentChild(DataTableColumnCellTreeToggle, { read: TemplateRef })
   treeToggleTemplate: TemplateRef<any>;
   private isFirstChange = true;
-  
+
   constructor(private columnChangesService: ColumnChangesService) {}
-  
+
   ngOnChanges() {
     if (this.isFirstChange) {
       this.isFirstChange = false;

--- a/src/types/table-column.type.ts
+++ b/src/types/table-column.type.ts
@@ -166,6 +166,14 @@ export interface TableColumn {
   prop?: TableColumnProp;
 
   /**
+   * Column uid or label
+   *
+   * @type {string}
+   * @memberOf TableColumn
+   */
+  uid?: string;
+
+  /**
    * Cell template ref
    *
    * @type {*}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When we receive a `click event`, the column data does not give us a way to distinguish between the columns.
We have `prop` (that enables sort), we have `label` but both of them are displayed at the column title.
The problem here is that if we create columns without label and prop is not possible to distinguish each one of them. 
The reason to do not use `label/prop` is that if we do we end up enabling sort or displaying the title and we want to use multiple empty column headers.

**What is the new behavior?**
Added `@Input() uid: string` to the column component enabling us to distinguish one column from each other.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
I've tested and it seems to be ok. Also, I used lint to trim spaces. 