### PR TITLE
#1474 Remember first selected row index for multi selection

### DIFF
--- a/src/components/body/selection.component.ts
+++ b/src/components/body/selection.component.ts
@@ -65,7 +65,9 @@ export class DataTableSelectionComponent {
     this.selected.splice(0, this.selected.length);
     this.selected.push(...selected);
 
-    this.prevIndex = index;
+    if (multi && !event.shiftKey) {
+        this.prevIndex = index;
+    }
 
     this.select.emit({
       selected


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Link to open issue: https://github.com/swimlane/ngx-datatable/issues/1474


**What is the new behavior?**
When we select for example 2 rows and then select for example another two rows then we can see selected four rows. 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
