### PR TITLE
Fix compile error when using TemplateTypeCheck set to true

### DIFF
--- a/src/components/body/body-cell.component.ts
+++ b/src/components/body/body-cell.component.ts
@@ -393,8 +393,8 @@ export class DataTableBodyCellComponent implements DoCheck, OnDestroy {
     return html.replace(/<\/?[^>]+(>|$)/g, '');
   }
 
-  onTreeAction(row: any) {
-    this.treeAction.emit();
+  onTreeAction() {
+    this.treeAction.emit(this.row);
   }
 
   calcLeftMargin(column: any, row: any) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
1. Compilation error:
ERROR in node_modules/@swimlane/ngx-datatable/release/components/body/body-cell.component.d.ts.DataTableBodyCellComponent.html(17,11): : Expected 1 arguments, but got 0.

2. And onTreeAction in DataTableBodyCellComponent doesn't send the row

**What is the new behavior?**
1. No compilation error.
2. onTreeAction now sends the row

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
