### PR TITLE
Add a resize handle to header columns in the bootstrap theme

### DIFF
--- a/src/themes/bootstrap.scss
+++ b/src/themes/bootstrap.scss
@@ -14,6 +14,9 @@ bootstrap table theme
       .datatable-header-cell-label {
         line-height: 24px;
       }
+      .resize-handle {
+        border-right: solid 1px #d1d4d7;
+      }
     }
   }
   .datatable-body {


### PR DESCRIPTION
Add a resize handle to header columns in the bootstrap theme, similar to the Material theme.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Resize handle is missing in the bootstrap theme (compared to the Material theme). Difficult to know where to grab to resize columns.


**What is the new behavior?**
Add a border to "grab" to resize columns in the bootstrap theme.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
