### PR TITLE
Include row index in cell class callback function

### DIFF
--- a/src/components/body/body-cell.component.ts
+++ b/src/components/body/body-cell.component.ts
@@ -184,7 +184,8 @@ export class DataTableBodyCellComponent implements DoCheck, OnDestroy {
           group: this.group,
           column: this.column,
           value: this.value ,
-          rowHeight: this.rowHeight
+          rowHeight: this.rowHeight,
+          rowIndex: this.rowIndex
         });
 
         if (typeof res === 'string') {


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

In a previous version of the table (9.x) the cellClass callback's row argument included a property $$index, which allowed the consumer of the control to style cells based on the row index.  This was useful in particular when using frozen first columns, to ensure the background color for alternating rows can be applied correctly, but in theory could enable other cell styling scenarios based on the row index.  In the current version of the table, the row index is no longer included in this callback.

**What is the new behavior?**

The row index is included as an additional argument in the callback.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
