### PR TITLE
ADD touch/mobile support to column resizing and reordering

### DIFF
--- a/src/directives/draggable.directive.ts
+++ b/src/directives/draggable.directive.ts
@@ -66,8 +66,10 @@ export class DraggableDirective implements OnDestroy, OnChanges {
     if (isDragElm && (this.dragX || this.dragY)) {
       event.preventDefault();
       this.isDragging = true;
-      const clientX = (<MouseEvent>event).clientX || (<TouchEvent>event).targetTouches[0].clientX;
-      const clientY = (<MouseEvent>event).clientY || (<TouchEvent>event).targetTouches[0].clientY;
+      const clientX = (<MouseEvent>event).clientX ||
+        ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientX);
+      const clientY = (<MouseEvent>event).clientY ||
+        ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientY);
       const mouseDownPos = { x: clientX, y: clientY };
 
       const mouseup = merge(
@@ -95,8 +97,10 @@ export class DraggableDirective implements OnDestroy, OnChanges {
   move(event: MouseEvent | TouchEvent, mouseDownPos: { x: number, y: number }): void {
     if (!this.isDragging) return;
 
-    const clientX = (<MouseEvent>event).clientX || (<TouchEvent>event).targetTouches[0].clientX;
-    const clientY = (<MouseEvent>event).clientY || (<TouchEvent>event).targetTouches[0].clientY;
+    const clientX = (<MouseEvent>event).clientX ||
+      ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientX);
+    const clientY = (<MouseEvent>event).clientY ||
+      ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientY);
     const x = clientX - mouseDownPos.x;
     const y = clientY - mouseDownPos.y;
 

--- a/src/directives/draggable.directive.ts
+++ b/src/directives/draggable.directive.ts
@@ -1,9 +1,9 @@
 import {
   Directive, ElementRef, Input, Output, EventEmitter, OnDestroy, OnChanges, SimpleChanges
 } from '@angular/core';
-import { Observable, Subscription, fromEvent } from 'rxjs';
+import { Observable, Subscription, fromEvent, merge } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { MouseEvent } from '../events';
+import { MouseEvent, TouchEvent } from '../events';
 
 /**
  * Draggable Directive for Angular2
@@ -43,7 +43,7 @@ export class DraggableDirective implements OnDestroy, OnChanges {
     this._destroySubscription();
   }
 
-  onMouseup(event: MouseEvent): void {
+  onMouseup(event: MouseEvent | TouchEvent): void {
     if (!this.isDragging) return;
 
     this.isDragging = false;
@@ -59,23 +59,28 @@ export class DraggableDirective implements OnDestroy, OnChanges {
     }
   }
 
-  onMousedown(event: MouseEvent): void {
+  onMousedown(event: MouseEvent | TouchEvent): void {
     // we only want to drag the inner header text
     const isDragElm = (<HTMLElement>event.target).classList.contains('draggable');
 
     if (isDragElm && (this.dragX || this.dragY)) {
       event.preventDefault();
       this.isDragging = true;
+      const clientX = (<MouseEvent>event).clientX || (<TouchEvent>event).targetTouches[0].clientX;
+      const clientY = (<MouseEvent>event).clientY || (<TouchEvent>event).targetTouches[0].clientY;
+      const mouseDownPos = { x: clientX, y: clientY };
 
-      const mouseDownPos = { x: event.clientX, y: event.clientY };
-
-      const mouseup = fromEvent(document, 'mouseup');
+      const mouseup = merge(
+        fromEvent(document, 'mouseup'),
+        fromEvent(document, 'touchend'));
       this.subscription = mouseup
-        .subscribe((ev: MouseEvent) => this.onMouseup(ev));
+        .subscribe((ev: MouseEvent | TouchEvent) => this.onMouseup(ev));
 
-      const mouseMoveSub = fromEvent(document, 'mousemove')
+      const mouseMoveSub = merge(
+        fromEvent(document, 'mousemove'),
+        fromEvent(document, 'touchmove'))
         .pipe(takeUntil(mouseup))
-        .subscribe((ev: MouseEvent) => this.move(ev, mouseDownPos));
+        .subscribe((ev: MouseEvent | TouchEvent) => this.move(ev, mouseDownPos));
 
       this.subscription.add(mouseMoveSub);
 
@@ -87,11 +92,13 @@ export class DraggableDirective implements OnDestroy, OnChanges {
     }
   }
 
-  move(event: MouseEvent, mouseDownPos: { x: number, y: number }): void {
+  move(event: MouseEvent | TouchEvent, mouseDownPos: { x: number, y: number }): void {
     if (!this.isDragging) return;
 
-    const x = event.clientX - mouseDownPos.x;
-    const y = event.clientY - mouseDownPos.y;
+    const clientX = (<MouseEvent>event).clientX || (<TouchEvent>event).targetTouches[0].clientX;
+    const clientY = (<MouseEvent>event).clientY || (<TouchEvent>event).targetTouches[0].clientY;
+    const x = clientX - mouseDownPos.x;
+    const y = clientY - mouseDownPos.y;
 
     if (this.dragX) this.element.style.left = `${x}px`;
     if (this.dragY) this.element.style.top = `${y}px`;

--- a/src/directives/long-press.directive.ts
+++ b/src/directives/long-press.directive.ts
@@ -41,8 +41,10 @@ export class LongPressDirective implements OnDestroy {
 
     // don't start drag if its on resize handle
     const target = (<HTMLElement>event.target);
-    const clientX = (<MouseEvent>event).clientX || (<TouchEvent>event).targetTouches[0].clientX;
-    const clientY = (<MouseEvent>event).clientY || (<TouchEvent>event).targetTouches[0].clientY;
+    const clientX = (<MouseEvent>event).clientX ||
+      ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientX);
+    const clientY = (<MouseEvent>event).clientY ||
+      ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientY);
     if (target.classList.contains('resize-handle')) return;
 
     this.mouseX = clientX;
@@ -77,8 +79,10 @@ export class LongPressDirective implements OnDestroy {
 
   onMouseMove(event: MouseEvent | TouchEvent): void {
     if (this.pressing && !this.isLongPressing) {
-      const clientX = (<MouseEvent>event).clientX || (<TouchEvent>event).targetTouches[0].clientX;
-      const clientY = (<MouseEvent>event).clientY || (<TouchEvent>event).targetTouches[0].clientY;
+      const clientX = (<MouseEvent>event).clientX ||
+        ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientX);
+      const clientY = (<MouseEvent>event).clientY ||
+        ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientY);
       const xThres = Math.abs(clientX - this.mouseX) > 10;
       const yThres = Math.abs(clientY - this.mouseY) > 10;
 

--- a/src/directives/long-press.directive.ts
+++ b/src/directives/long-press.directive.ts
@@ -2,9 +2,9 @@ import {
   Directive, Input, Output, EventEmitter, HostBinding,
   HostListener, OnDestroy
 } from '@angular/core';
-import { Observable, Subscription, fromEvent } from 'rxjs';
+import { Observable, Subscription, fromEvent, merge } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { MouseEvent } from '../events';
+import { MouseEvent, TouchEvent } from '../events';
 
 @Directive({ selector: '[long-press]' })
 export class LongPressDirective implements OnDestroy {
@@ -34,22 +34,27 @@ export class LongPressDirective implements OnDestroy {
   }
 
   @HostListener('mousedown', ['$event'])
-  onMouseDown(event: MouseEvent): void {
+  @HostListener('touchstart', ['$event'])
+  onMouseDown(event: MouseEvent | TouchEvent): void {
     // don't do right/middle clicks
-    if (event.which !== 1 || !this.pressEnabled) return;
+    if ((event.which !== 1 || !this.pressEnabled) && event.type !== 'touchstart') return;
 
     // don't start drag if its on resize handle
     const target = (<HTMLElement>event.target);
+    const clientX = (<MouseEvent>event).clientX || (<TouchEvent>event).targetTouches[0].clientX;
+    const clientY = (<MouseEvent>event).clientY || (<TouchEvent>event).targetTouches[0].clientY;
     if (target.classList.contains('resize-handle')) return;
 
-    this.mouseX = event.clientX;
-    this.mouseY = event.clientY;
+    this.mouseX = clientX;
+    this.mouseY = clientY;
 
     this.pressing = true;
     this.isLongPressing = false;
 
-    const mouseup = fromEvent(document, 'mouseup');
-    this.subscription = mouseup.subscribe((ev: MouseEvent) => this.onMouseup());
+    const mouseup = merge(
+      fromEvent(document, 'mouseup'),
+      fromEvent(document, 'touchend'));
+    this.subscription = mouseup.subscribe((ev: MouseEvent | TouchEvent) => this.onMouseup());
 
     this.timeout = setTimeout(() => {
       this.isLongPressing = true;
@@ -61,7 +66,7 @@ export class LongPressDirective implements OnDestroy {
       this.subscription.add(
         fromEvent(document, 'mousemove')
           .pipe(takeUntil(mouseup))
-          .subscribe((mouseEvent: MouseEvent) => this.onMouseMove(mouseEvent))
+          .subscribe((mouseEvent: MouseEvent | TouchEvent) => this.onMouseMove(mouseEvent))
       );
 
       this.loop(event);
@@ -70,10 +75,12 @@ export class LongPressDirective implements OnDestroy {
     this.loop(event);
   }
 
-  onMouseMove(event: MouseEvent): void {
+  onMouseMove(event: MouseEvent | TouchEvent): void {
     if (this.pressing && !this.isLongPressing) {
-      const xThres = Math.abs(event.clientX - this.mouseX) > 10;
-      const yThres = Math.abs(event.clientY - this.mouseY) > 10;
+      const clientX = (<MouseEvent>event).clientX || (<TouchEvent>event).targetTouches[0].clientX;
+      const clientY = (<MouseEvent>event).clientY || (<TouchEvent>event).targetTouches[0].clientY;
+      const xThres = Math.abs(clientX - this.mouseX) > 10;
+      const yThres = Math.abs(clientY - this.mouseY) > 10;
 
       if (xThres || yThres) {
         this.endPress();
@@ -81,7 +88,7 @@ export class LongPressDirective implements OnDestroy {
     }
   }
 
-  loop(event: MouseEvent): void {
+  loop(event: MouseEvent | TouchEvent): void {
     if (this.isLongPressing) {
       this.timeout = setTimeout(() => {
         this.longPressing.emit({

--- a/src/directives/orderable.directive.ts
+++ b/src/directives/orderable.directive.ts
@@ -82,7 +82,7 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
   }
 
   onDragging({ element, model, event }: any): void {
-    const prevPos = this.positions[ model.prop ];    
+    const prevPos = this.positions[ model.prop ];
     const target = this.isTarget(model, event);
 
     if (target) {
@@ -93,7 +93,7 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
           initialIndex: prevPos.index
         });
         this.lastDraggingIndex = target.i;
-      } 
+      }
     } else if (this.lastDraggingIndex !== prevPos.index) {
       this.targetChanged.emit({
         prevIndex: this.lastDraggingIndex,
@@ -121,8 +121,8 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
 
   isTarget(model: any, event: any): any {
     let i = 0;
-    const x = event.x || event.clientX;
-    const y = event.y || event.clientY;
+    const x = event.x || event.clientX || event.changedTouches[0].clientX;
+    const y = event.y || event.clientY || event.changedTouches[0].clientY;
     const targets = this.document.elementsFromPoint(x, y);
 
     for (const prop in this.positions) {

--- a/src/directives/orderable.directive.ts
+++ b/src/directives/orderable.directive.ts
@@ -121,8 +121,8 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
 
   isTarget(model: any, event: any): any {
     let i = 0;
-    const x = event.x || event.clientX || event.changedTouches[0].clientX;
-    const y = event.y || event.clientY || event.changedTouches[0].clientY;
+    const x = event.x || event.clientX || (event.changedTouches && event.changedTouches[0].clientX);
+    const y = event.y || event.clientY || (event.changedTouches && event.changedTouches[0].clientY);
     const targets = this.document.elementsFromPoint(x, y);
 
     for (const prop in this.positions) {

--- a/src/directives/resizeable.directive.ts
+++ b/src/directives/resizeable.directive.ts
@@ -1,8 +1,8 @@
 import {
   Directive, ElementRef, HostListener, Input, Output, EventEmitter, OnDestroy, AfterViewInit, Renderer2
 } from '@angular/core';
-import { Observable, Subscription, fromEvent } from 'rxjs';
-import { MouseEvent } from '../events';
+import { Observable, Subscription, fromEvent, merge } from 'rxjs';
+import { MouseEvent, TouchEvent } from '../events';
 import { takeUntil } from 'rxjs/operators';
 
 @Directive({
@@ -52,29 +52,37 @@ export class ResizeableDirective implements OnDestroy, AfterViewInit {
   }
 
   @HostListener('mousedown', ['$event'])
-  onMousedown(event: MouseEvent): void {
+  @HostListener('touchstart', ['$event'])
+  onMousedown(event: MouseEvent | TouchEvent): void {
     const isHandle = (<HTMLElement>(event.target)).classList.contains('resize-handle');
     const initialWidth = this.element.clientWidth;
-    const mouseDownScreenX = event.screenX;
+    const mouseDownScreenX = (<MouseEvent>event).screenX || (<TouchEvent>event).targetTouches[0].screenX;
 
     if (isHandle) {
       event.stopPropagation();
       this.resizing = true;
 
-      const mouseup = fromEvent(document, 'mouseup');
+      const mouseup = merge(
+        fromEvent(document, 'mouseup'),
+        fromEvent(document, 'touchend')
+      );
       this.subscription = mouseup
-        .subscribe((ev: MouseEvent) => this.onMouseup());
+        .subscribe((ev: MouseEvent | TouchEvent) => this.onMouseup());
 
-      const mouseMoveSub = fromEvent(document, 'mousemove')
+      const mouseMoveSub = merge(
+        fromEvent(document, 'mousemove'),
+        fromEvent(document, 'touchmove')
+      )
         .pipe(takeUntil(mouseup))
-        .subscribe((e: MouseEvent) => this.move(e, initialWidth, mouseDownScreenX));
+        .subscribe((e: MouseEvent | TouchEvent) => this.move(e, initialWidth, mouseDownScreenX));
 
       this.subscription.add(mouseMoveSub);
     }
   }
 
-  move(event: MouseEvent, initialWidth: number, mouseDownScreenX: number): void {
-    const movementX = event.screenX - mouseDownScreenX;
+  move(event: MouseEvent | TouchEvent, initialWidth: number, mouseDownScreenX: number): void {
+    const screenX = (<MouseEvent>event).screenX || (<TouchEvent>event).targetTouches[0].screenX;
+    const movementX = screenX - mouseDownScreenX;
     const newWidth = initialWidth + movementX;
 
     const overMinWidth = !this.minWidth || newWidth >= this.minWidth;

--- a/src/directives/resizeable.directive.ts
+++ b/src/directives/resizeable.directive.ts
@@ -1,103 +1,125 @@
 import {
-  Directive, ElementRef, HostListener, Input, Output, EventEmitter, OnDestroy, AfterViewInit, Renderer2
+  Directive, ElementRef, Input, Output, EventEmitter, OnDestroy, OnChanges, SimpleChanges
 } from '@angular/core';
 import { Observable, Subscription, fromEvent, merge } from 'rxjs';
-import { MouseEvent, TouchEvent } from '../events';
 import { takeUntil } from 'rxjs/operators';
+import { MouseEvent, TouchEvent } from '../events';
 
-@Directive({
-  selector: '[resizeable]',
-  host: {
-    '[class.resizeable]': 'resizeEnabled'
-  }
-})
-export class ResizeableDirective implements OnDestroy, AfterViewInit {
+/**
+ * Draggable Directive for Angular2
+ *
+ * Inspiration:
+ *   https://github.com/AngularClass/angular2-examples/blob/master/rx-draggable/directives/draggable.ts
+ *   http://stackoverflow.com/questions/35662530/how-to-implement-drag-and-drop-in-angular2
+ *
+ */
+@Directive({ selector: '[draggable]' })
+export class DraggableDirective implements OnDestroy, OnChanges {
 
-  @Input() resizeEnabled: boolean = true;
-  @Input() minWidth: number;
-  @Input() maxWidth: number;
+  @Input() dragEventTarget: any;
+  @Input() dragModel: any;
+  @Input() dragX: boolean = true;
+  @Input() dragY: boolean = true;
 
-  @Output() resize: EventEmitter<any> = new EventEmitter();
+  @Output() dragStart: EventEmitter<any> = new EventEmitter();
+  @Output() dragging: EventEmitter<any> = new EventEmitter();
+  @Output() dragEnd: EventEmitter<any> = new EventEmitter();
 
   element: HTMLElement;
+  isDragging: boolean = false;
   subscription: Subscription;
-  resizing: boolean = false;
 
-  constructor(element: ElementRef, private renderer: Renderer2) {
+  constructor(element: ElementRef) {
     this.element = element.nativeElement;
   }
 
-  ngAfterViewInit(): void {
-    const renderer2 = this.renderer;
-    const node = renderer2.createElement('span');
-    if (this.resizeEnabled) {
-      renderer2.addClass(node, 'resize-handle');
-    } else {
-      renderer2.addClass(node, 'resize-handle--not-resizable');
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['dragEventTarget'] && changes['dragEventTarget'].currentValue && this.dragModel.dragging) {
+      this.onMousedown(changes['dragEventTarget'].currentValue);
     }
-    renderer2.appendChild(this.element, node);
   }
 
   ngOnDestroy(): void {
     this._destroySubscription();
   }
 
-  onMouseup(): void {
-    this.resizing = false;
+  onMouseup(event: MouseEvent | TouchEvent): void {
+    if (!this.isDragging) return;
 
-    if (this.subscription && !this.subscription.closed) {
+    this.isDragging = false;
+    this.element.classList.remove('dragging');
+
+    if (this.subscription) {
       this._destroySubscription();
-      this.resize.emit(this.element.clientWidth);
+      this.dragEnd.emit({
+        event,
+        element: this.element,
+        model: this.dragModel
+      });
     }
   }
 
-  @HostListener('mousedown', ['$event'])
-  @HostListener('touchstart', ['$event'])
   onMousedown(event: MouseEvent | TouchEvent): void {
-    const isHandle = (<HTMLElement>(event.target)).classList.contains('resize-handle');
-    const initialWidth = this.element.clientWidth;
-    const mouseDownScreenX = (<MouseEvent>event).screenX || (<TouchEvent>event).targetTouches[0].screenX;
+    // we only want to drag the inner header text
+    const isDragElm = (<HTMLElement>event.target).classList.contains('draggable');
 
-    if (isHandle) {
-      event.stopPropagation();
-      this.resizing = true;
+    if (isDragElm && (this.dragX || this.dragY)) {
+      event.preventDefault();
+      this.isDragging = true;
+      const clientX = (<MouseEvent>event).clientX ||
+        ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientX);
+      const clientY = (<MouseEvent>event).clientY ||
+        ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientY);
+      const mouseDownPos = { x: clientX, y: clientY };
 
       const mouseup = merge(
         fromEvent(document, 'mouseup'),
-        fromEvent(document, 'touchend')
-      );
+        fromEvent(document, 'touchend'));
       this.subscription = mouseup
-        .subscribe((ev: MouseEvent | TouchEvent) => this.onMouseup());
+        .subscribe((ev: MouseEvent | TouchEvent) => this.onMouseup(ev));
 
       const mouseMoveSub = merge(
         fromEvent(document, 'mousemove'),
-        fromEvent(document, 'touchmove')
-      )
+        fromEvent(document, 'touchmove'))
         .pipe(takeUntil(mouseup))
-        .subscribe((e: MouseEvent | TouchEvent) => this.move(e, initialWidth, mouseDownScreenX));
+        .subscribe((ev: MouseEvent | TouchEvent) => this.move(ev, mouseDownPos));
 
       this.subscription.add(mouseMoveSub);
+
+      this.dragStart.emit({
+        event,
+        element: this.element,
+        model: this.dragModel
+      });
     }
   }
 
-  move(event: MouseEvent | TouchEvent, initialWidth: number, mouseDownScreenX: number): void {
-    const screenX = (<MouseEvent>event).screenX || (<TouchEvent>event).targetTouches[0].screenX;
-    const movementX = screenX - mouseDownScreenX;
-    const newWidth = initialWidth + movementX;
+  move(event: MouseEvent | TouchEvent, mouseDownPos: { x: number, y: number }): void {
+    if (!this.isDragging) return;
 
-    const overMinWidth = !this.minWidth || newWidth >= this.minWidth;
-    const underMaxWidth = !this.maxWidth || newWidth <= this.maxWidth;
+    const clientX = (<MouseEvent>event).clientX ||
+      ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientX);
+    const clientY = (<MouseEvent>event).clientY ||
+      ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientY);
+    const x = clientX - mouseDownPos.x;
+    const y = clientY - mouseDownPos.y;
 
-    if (overMinWidth && underMaxWidth) {
-      this.element.style.width = `${newWidth}px`;
-    }
+    if (this.dragX) this.element.style.left = `${x}px`;
+    if (this.dragY) this.element.style.top = `${y}px`;
+
+    this.element.classList.add('dragging');
+
+    this.dragging.emit({
+      event,
+      element: this.element,
+      model: this.dragModel
+    });
   }
 
-  private _destroySubscription() {
+  private _destroySubscription(): void {
     if (this.subscription) {
       this.subscription.unsubscribe();
       this.subscription = undefined;
     }
   }
-
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -2,5 +2,6 @@ declare let global: any;
 
 /* tslint:disable */
 export const MouseEvent = (((typeof window !== 'undefined' && window) as any) || (global as any)).MouseEvent as MouseEvent;
+export const TouchEvent = (((typeof window !== 'undefined' && window) as any) || (global as any)).TouchEvent as TouchEvent;
 export const KeyboardEvent = (((typeof window !== 'undefined' && window) as any) || (global as any)).KeyboardEvent as KeyboardEvent;
 export const Event = (((typeof window !== 'undefined' && window) as any) || (global as any)).Event as Event;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ x] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Touch devices do not support column resizing and reordering.


**What is the new behavior?**
The PR enables column resizing and reordering in touch devices by tapping in touchstart, touchmove and touchend events with mousedown, mousemove and mouseup respectively.

Use Cases:
The developers can customize the resize handle for touch devices like below which enables the user to resize easily on touch devices.



![ngx-resize](https://user-images.githubusercontent.com/5536154/46950752-6e164500-d0a3-11e8-8718-afa238c74a20.PNG)

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
