### PR TITLE
ADD touch/mobile support for column resizing and reordering

### DIFF
--- a/src/directives/draggable.directive.ts
+++ b/src/directives/draggable.directive.ts
@@ -1,9 +1,9 @@
 import {
   Directive, ElementRef, Input, Output, EventEmitter, OnDestroy, OnChanges, SimpleChanges
 } from '@angular/core';
-import { Observable, Subscription, fromEvent } from 'rxjs';
+import { Observable, Subscription, fromEvent, merge } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { MouseEvent } from '../events';
+import { MouseEvent, TouchEvent } from '../events';
 
 /**
  * Draggable Directive for Angular2
@@ -43,7 +43,7 @@ export class DraggableDirective implements OnDestroy, OnChanges {
     this._destroySubscription();
   }
 
-  onMouseup(event: MouseEvent): void {
+  onMouseup(event: MouseEvent | TouchEvent): void {
     if (!this.isDragging) return;
 
     this.isDragging = false;
@@ -59,23 +59,30 @@ export class DraggableDirective implements OnDestroy, OnChanges {
     }
   }
 
-  onMousedown(event: MouseEvent): void {
+  onMousedown(event: MouseEvent | TouchEvent): void {
     // we only want to drag the inner header text
     const isDragElm = (<HTMLElement>event.target).classList.contains('draggable');
 
     if (isDragElm && (this.dragX || this.dragY)) {
       event.preventDefault();
       this.isDragging = true;
+      const clientX = (<MouseEvent>event).clientX ||
+        ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientX);
+      const clientY = (<MouseEvent>event).clientY ||
+        ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientY);
+      const mouseDownPos = { x: clientX, y: clientY };
 
-      const mouseDownPos = { x: event.clientX, y: event.clientY };
-
-      const mouseup = fromEvent(document, 'mouseup');
+      const mouseup = merge(
+        fromEvent(document, 'mouseup'),
+        fromEvent(document, 'touchend'));
       this.subscription = mouseup
-        .subscribe((ev: MouseEvent) => this.onMouseup(ev));
+        .subscribe((ev: MouseEvent | TouchEvent) => this.onMouseup(ev));
 
-      const mouseMoveSub = fromEvent(document, 'mousemove')
+      const mouseMoveSub = merge(
+        fromEvent(document, 'mousemove'),
+        fromEvent(document, 'touchmove'))
         .pipe(takeUntil(mouseup))
-        .subscribe((ev: MouseEvent) => this.move(ev, mouseDownPos));
+        .subscribe((ev: MouseEvent | TouchEvent) => this.move(ev, mouseDownPos));
 
       this.subscription.add(mouseMoveSub);
 
@@ -87,11 +94,15 @@ export class DraggableDirective implements OnDestroy, OnChanges {
     }
   }
 
-  move(event: MouseEvent, mouseDownPos: { x: number, y: number }): void {
+  move(event: MouseEvent | TouchEvent, mouseDownPos: { x: number, y: number }): void {
     if (!this.isDragging) return;
 
-    const x = event.clientX - mouseDownPos.x;
-    const y = event.clientY - mouseDownPos.y;
+    const clientX = (<MouseEvent>event).clientX ||
+      ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientX);
+    const clientY = (<MouseEvent>event).clientY ||
+      ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].clientY);
+    const x = clientX - mouseDownPos.x;
+    const y = clientY - mouseDownPos.y;
 
     if (this.dragX) this.element.style.left = `${x}px`;
     if (this.dragY) this.element.style.top = `${y}px`;

--- a/src/directives/orderable.directive.ts
+++ b/src/directives/orderable.directive.ts
@@ -82,7 +82,7 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
   }
 
   onDragging({ element, model, event }: any): void {
-    const prevPos = this.positions[ model.prop ];    
+    const prevPos = this.positions[ model.prop ];
     const target = this.isTarget(model, event);
 
     if (target) {
@@ -93,7 +93,7 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
           initialIndex: prevPos.index
         });
         this.lastDraggingIndex = target.i;
-      } 
+      }
     } else if (this.lastDraggingIndex !== prevPos.index) {
       this.targetChanged.emit({
         prevIndex: this.lastDraggingIndex,
@@ -121,8 +121,8 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
 
   isTarget(model: any, event: any): any {
     let i = 0;
-    const x = event.x || event.clientX;
-    const y = event.y || event.clientY;
+    const x = event.x || event.clientX || (event.changedTouches && event.changedTouches[0].clientX);
+    const y = event.y || event.clientY || (event.changedTouches && event.changedTouches[0].clientY);
     const targets = this.document.elementsFromPoint(x, y);
 
     for (const prop in this.positions) {

--- a/src/directives/resizeable.directive.ts
+++ b/src/directives/resizeable.directive.ts
@@ -1,8 +1,8 @@
 import {
   Directive, ElementRef, HostListener, Input, Output, EventEmitter, OnDestroy, AfterViewInit, Renderer2
 } from '@angular/core';
-import { Observable, Subscription, fromEvent } from 'rxjs';
-import { MouseEvent } from '../events';
+import { Observable, Subscription, fromEvent, merge } from 'rxjs';
+import { MouseEvent, TouchEvent } from '../events';
 import { takeUntil } from 'rxjs/operators';
 
 @Directive({
@@ -52,29 +52,39 @@ export class ResizeableDirective implements OnDestroy, AfterViewInit {
   }
 
   @HostListener('mousedown', ['$event'])
-  onMousedown(event: MouseEvent): void {
+  @HostListener('touchstart', ['$event'])
+  onMousedown(event: MouseEvent | TouchEvent): void {
     const isHandle = (<HTMLElement>(event.target)).classList.contains('resize-handle');
     const initialWidth = this.element.clientWidth;
-    const mouseDownScreenX = event.screenX;
+    const mouseDownScreenX = (<MouseEvent>event).screenX ||
+      ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].screenX);
 
     if (isHandle) {
       event.stopPropagation();
       this.resizing = true;
 
-      const mouseup = fromEvent(document, 'mouseup');
+      const mouseup = merge(
+        fromEvent(document, 'mouseup'),
+        fromEvent(document, 'touchend')
+      );
       this.subscription = mouseup
-        .subscribe((ev: MouseEvent) => this.onMouseup());
+        .subscribe((ev: MouseEvent | TouchEvent) => this.onMouseup());
 
-      const mouseMoveSub = fromEvent(document, 'mousemove')
+      const mouseMoveSub = merge(
+        fromEvent(document, 'mousemove'),
+        fromEvent(document, 'touchmove')
+      )
         .pipe(takeUntil(mouseup))
-        .subscribe((e: MouseEvent) => this.move(e, initialWidth, mouseDownScreenX));
+        .subscribe((e: MouseEvent | TouchEvent) => this.move(e, initialWidth, mouseDownScreenX));
 
       this.subscription.add(mouseMoveSub);
     }
   }
 
-  move(event: MouseEvent, initialWidth: number, mouseDownScreenX: number): void {
-    const movementX = event.screenX - mouseDownScreenX;
+  move(event: MouseEvent | TouchEvent, initialWidth: number, mouseDownScreenX: number): void {
+    const screenX = (<MouseEvent>event).screenX ||
+      ((<TouchEvent>event).targetTouches && (<TouchEvent>event).targetTouches[0].screenX);
+    const movementX = screenX - mouseDownScreenX;
     const newWidth = initialWidth + movementX;
 
     const overMinWidth = !this.minWidth || newWidth >= this.minWidth;

--- a/src/events.ts
+++ b/src/events.ts
@@ -2,5 +2,6 @@ declare let global: any;
 
 /* tslint:disable */
 export const MouseEvent = (((typeof window !== 'undefined' && window) as any) || (global as any)).MouseEvent as MouseEvent;
+export const TouchEvent = (((typeof window !== 'undefined' && window) as any) || (global as any)).TouchEvent as TouchEvent;
 export const KeyboardEvent = (((typeof window !== 'undefined' && window) as any) || (global as any)).KeyboardEvent as KeyboardEvent;
 export const Event = (((typeof window !== 'undefined' && window) as any) || (global as any)).Event as Event;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ x] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Touch devices do not support column resizing and reordering.



**What is the new behavior?**
The PR enables column resizing and reordering in touch devices by tapping in touchstart, touchmove and touchend events with mousedown, mousemove and mouseup respectively.

Use Cases:
The developers can customize the resize handle for touch devices like below which enables the user to resize easily on touch devices.

![ngx-resize](https://user-images.githubusercontent.com/5536154/46973769-dc78f880-d0df-11e8-9775-16df4cb3b80b.PNG)



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
