### PR TITLE
Fix bug: calcPageSize return NaN for virtual scroll with dynamic row height

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -235,7 +235,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    * The row height; which is necessary
    * to calculate the height for the lazy rendering.
    */
-  @Input() rowHeight: number = 30;
+  @Input() rowHeight: number | (() => number) = 30;
 
   /**
    * Type of column width distribution formula.
@@ -540,7 +540,8 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    */
   @HostBinding('class.fixed-row')
   get isFixedRow(): boolean {
-    const rowHeight: number | string = this.rowHeight;
+    const height = (typeof this.rowHeight === 'function') ? this.rowHeight() : this.rowHeight;
+    const rowHeight: number | string = height;
     return (typeof rowHeight === 'string') ?
       (<string>rowHeight) !== 'auto' : true;
   }
@@ -979,7 +980,8 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
     // This is because an expanded row is still considered to be a child of
     // the original row.  Hence calculation would use rowHeight only.
     if (this.scrollbarV && this.virtualization) {
-      const size = Math.ceil(this.bodyHeight / this.rowHeight);
+      const height = (typeof this.rowHeight === 'function') ? this.rowHeight() : this.rowHeight;
+      const size = Math.ceil(this.bodyHeight / height);
       return Math.max(size, 0);
     }
 


### PR DESCRIPTION
If you set virtual scroll with dynamic row height, calcPageSize() always return NaN;

**What kind of change does this PR introduce?** (check one with "x")
- [ + ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
calcPageSize returns NaN for virtual scroll with dynamic row height.


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ + ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
