### PR TITLE
#1049 Preserve group expansion state when updating rows

### DIFF
--- a/src/components/body/body.component.spec.ts
+++ b/src/components/body/body.component.spec.ts
@@ -112,4 +112,210 @@ describe('DataTableBodyComponent', () => {
       expect(styles).toBeDefined();
     });
   });
+
+  fdescribe('Row grouping', () => {
+
+    var groupExpansionDefaultTestCases = [
+      { value: true },
+      { value: false }
+    ];
+
+    groupExpansionDefaultTestCases.forEach(function(testCase: any) {
+      it('should apply default group expansion to all groups when default is ' + testCase.value.toString(), () => {
+        let rows = [
+          {
+            key: '20', value: [
+              {age: '20', name: 'name1'},
+              {age: '20', name: 'name2'},
+            ]
+          },
+          {
+            key: '30', value: [
+              {age: '30', name: 'name3'},
+              {age: '30', name: 'name4'},
+              {age: '30', name: 'name5'},
+            ],
+          },
+          {
+            key: '40', value: [
+              {age: '40', name: 'name6'},
+            ],
+          }
+        ];
+
+        component.groupExpansionDefault =  testCase.value;
+        component.rows = rows;
+        rows.forEach(function(row) {
+          let expanded = component.getRowExpanded(row);
+          expect(expanded).toBe(testCase.value);
+        });
+      });
+    });
+
+    groupExpansionDefaultTestCases.forEach(function(testCase: any) {
+      it('should apply default group expansion to all newly added groups when default expansion is ' + testCase.value.toString(), () => {
+        let rows = [
+          {
+            key: '20', value: [
+              {age: '20', name: 'name1'},
+              {age: '20', name: 'name2'},
+            ]
+          },
+          {
+            key: '30', value: [
+              {age: '30', name: 'name3'},
+              {age: '30', name: 'name4'},
+              {age: '30', name: 'name5'},
+            ],
+          },
+          {
+            key: '40', value: [
+              {age: '40', name: 'name6'},
+            ],
+          }
+        ];
+
+        component.groupExpansionDefault =  testCase.value;
+        component.rows = rows;
+
+        let updatedRows = [
+          {
+            key: '20', value: [
+              {age: '20', name: 'name1'},
+              {age: '20', name: 'name2'},
+              {age: '20', name: 'name7'},
+            ]
+          },
+          {
+            key: '30', value: [
+              {age: '30', name: 'name3'},
+              {age: '30', name: 'name4'},
+            ],
+          },
+          {
+            key: '50', value: [
+              {age: '50', name: 'name8'},
+            ],
+          }
+        ];
+
+        updatedRows.forEach(function(row) {
+          let expanded = component.getRowExpanded(row);
+          expect(expanded).toBe(testCase.value);
+        });
+      });
+    });
+
+    groupExpansionDefaultTestCases.forEach(function(testCase: any) {
+      it('should toggle group expansion state when requested when default expansion is ' + testCase.value.toString(), () => {
+        let rows = [
+          {
+            key: '20', value: [
+              {age: '20', name: 'name1'},
+              {age: '20', name: 'name2'},
+            ]
+          },
+          {
+            key: '30', value: [
+              {age: '30', name: 'name3'},
+              {age: '30', name: 'name4'},
+              {age: '30', name: 'name5'},
+            ],
+          },
+          {
+            key: '40', value: [
+              {age: '40', name: 'name6'},
+            ],
+          }
+        ];
+
+        component.groupExpansionDefault =  testCase.value;
+        component.rows = rows;
+
+        // Toggle away from default.
+        rows.forEach(function(row) {
+          var expanded = component.getRowExpanded(row);
+          component.toggleRowExpansion(row);
+          expanded = component.getRowExpanded(row);
+          expect(expanded).toBe(!testCase.value);
+        });
+
+        // Toggle back to default.
+        rows.forEach(function(row) {
+          var expanded = component.getRowExpanded(row);
+          component.toggleRowExpansion(row);
+          expanded = component.getRowExpanded(row);
+          expect(expanded).toBe(testCase.value);
+        });
+      });
+    });
+
+    groupExpansionDefaultTestCases.forEach(function(testCase: any) {
+      it('should preserve group expansion state when rows change when default expansion is ' + testCase.value.toString(), () => {
+        let rows = [
+          {
+            key: '20', value: [
+              {age: '20', name: 'name1'},
+              {age: '20', name: 'name2'},
+            ]
+          },
+          {
+            key: '30', value: [
+              {age: '30', name: 'name3'},
+              {age: '30', name: 'name4'},
+              {age: '30', name: 'name5'},
+            ],
+          },
+          {
+            key: '40', value: [
+              {age: '40', name: 'name6'},
+            ],
+          }
+        ];
+
+        component.groupExpansionDefault =  testCase.value;
+        component.rows = rows;
+
+        // Toggle a row
+        var expanded = component.getRowExpanded(rows[1]);
+        component.toggleRowExpansion(rows[1]);
+
+        // Update data
+        let updatedRows = [
+          {
+            key: '20', value: [
+              {age: '20', name: 'name1'},
+              {age: '20', name: 'name2'},
+              {age: '20', name: 'name7'},
+            ]
+          },
+          {
+            key: '30', value: [
+              {age: '30', name: 'name3'},
+              {age: '30', name: 'name4'},
+            ],
+          },
+          {
+            key: '50', value: [
+              {age: '50', name: 'name8'},
+            ],
+          }
+        ];
+
+        component.rows = updatedRows;
+
+        // First row should remain at default expansion value
+        expanded = component.getRowExpanded(rows[0]);
+        expect(expanded).toBe(testCase.value);
+
+        // Toggled row should remain at toggled expansion value
+        expanded = component.getRowExpanded(rows[1]);
+        expect(expanded).toBe(!testCase.value);
+
+        // Newly added row should be at default expansion value
+        expanded = component.getRowExpanded(rows[2]);
+        expect(expanded).toBe(testCase.value);
+      });
+    });
+  });
 });

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -146,7 +146,6 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
 
   @Input() set rows(val: any[]) {
     this._rows = val;
-    this.rowExpansions.clear();
     this.recalcLayout();
   }
 
@@ -452,7 +451,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    */
   getRowAndDetailHeight(row: any): number {
     let rowHeight = this.getRowHeight(row);
-    const expanded = this.rowExpansions.get(row);
+    const expanded = this.rowExpansions.get(row.key);
 
     // Adding detail row height if its expanded.
     if (expanded === 1) {
@@ -635,7 +634,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   toggleRowExpansion(row: any): void {
     // Capture the row index of the first row that is visible on the viewport.
     const viewPortFirstRowIndex = this.getAdjustedViewPortIndex();
-    let expanded = this.rowExpansions.get(row);
+    let expanded = this.rowExpansions.get(row.key);
 
     // If the detailRowHeight is auto --> only in case of non-virtualized scroll
     if (this.scrollbarV && this.virtualization) {
@@ -647,7 +646,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
 
     // Update the toggled row and update thive nevere heights in the cache.
     expanded = expanded ^= 1;
-    this.rowExpansions.set(row, expanded);
+    this.rowExpansions.set(row.key, expanded);
 
     this.detailToggle.emit({
       rows: [row],
@@ -668,7 +667,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     const viewPortFirstRowIndex = this.getAdjustedViewPortIndex();
 
     for (const row of this.rows) {
-      this.rowExpansions.set(row, rowExpanded);
+      this.rowExpansions.set(row.key, rowExpanded);
     }
 
     if (this.scrollbarV) {
@@ -727,13 +726,11 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    * Returns if the row was expanded and set default row expansion when row expansion is empty
    */
   getRowExpanded(row: any): boolean {
-    if (this.rowExpansions.size === 0 && this.groupExpansionDefault) {
-      for (const group of this.groupedRows) {
-        this.rowExpansions.set(group, 1);
-      }
+    if (!this.rowExpansions.has(row.key)) {
+      this.rowExpansions.set(row.key, this.groupExpansionDefault ? 1 : 0);
     }
 
-    const expanded = this.rowExpansions.get(row);
+    const expanded = this.rowExpansions.get(row.key);
     return expanded === 1;
   }
 

--- a/src/utils/row-height-cache.ts
+++ b/src/utils/row-height-cache.ts
@@ -62,7 +62,7 @@ export class RowHeightCache {
 
       // Add the detail row height to the already expanded rows.
       // This is useful for the table that goes through a filter or sort.
-      const expanded = rowExpansions.get(row);
+      const expanded = rowExpansions.get(row.key);
       if(row && expanded === 1) {
         if(isDetailFn) {
           const index = rowIndexes.get(row);


### PR DESCRIPTION
Use row key as key for rowExpansions map to ensure that group expansion state is maintained across row data updates.

Fixes issue #1049 Making a change to a row in a collapsed group causes the group to expand

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Issue is reproducible on demo page as per instructions here:
https://github.com/swimlane/ngx-datatable/issues/1049

**What is the new behavior?**
Data updates no longer cause groups to be collapsed/expanded.  Newly added groups will be set to the defined default expansion state as per table config.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
