### PR TITLE
Deactivate event that triggers on mouseleave

### DIFF
--- a/demo/selection/selection-single.component.ts
+++ b/demo/selection/selection-single.component.ts
@@ -28,7 +28,7 @@ import { Component } from '@angular/core';
           [limit]="5"
           [selected]="selected"
           [selectionType]="'single'"
-          (activate)="onActivate($event)"
+          (deactivate)="onDeactivate($event)"
           (select)='onSelect($event)'>
         </ngx-datatable>
       </div>
@@ -81,6 +81,10 @@ export class SingleSelectionComponent {
 
   onActivate(event) {
     console.log('Activate Event', event);
+  }
+
+  onDeactivate(event) {
+    console.log('Deactivate Event', event);
   }
 
 }

--- a/src/components/body/body-row.component.ts
+++ b/src/components/body/body-row.component.ts
@@ -110,6 +110,7 @@ export class DataTableBodyRowComponent implements DoCheck {
   }
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
+  @Output() deactivate: EventEmitter<any> = new EventEmitter();
   @Output() treeAction: EventEmitter<any> = new EventEmitter();
 
   _element: any;
@@ -183,6 +184,12 @@ export class DataTableBodyRowComponent implements DoCheck {
     this.activate.emit(event);
   }
 
+  onDeactivate(event: any, index: number): void {
+    event.cellIndex = index;
+    event.rowElement = this._element;
+    this.deactivate.emit(event);
+  }
+
   @HostListener('keydown', ['$event'])
   onKeyDown(event: KeyboardEvent): void {
     const keyCode = event.keyCode;
@@ -216,6 +223,15 @@ export class DataTableBodyRowComponent implements DoCheck {
         row: this.row,
         rowElement: this._element
       });
+  }
+  @HostListener('mouseleave', ['$event'])
+  onMouseleave(event: any): void {
+    this.deactivate.emit({
+      type: 'mouseleave',
+      event,
+      row: this.row,
+      rowElement: this._element
+    });
   }
 
   recalculateColumns(val: any[] = this.columns): void {

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -19,7 +19,8 @@ import { MouseEvent } from '../../events';
       [selectionType]="selectionType"
       [rowIdentity]="rowIdentity"
       (select)="select.emit($event)"
-      (activate)="activate.emit($event)">
+      (activate)="activate.emit($event)"
+      (deactivate)="deactivate.emit($event)">
       <datatable-progress
         *ngIf="loadingIndicator">
       </datatable-progress>
@@ -66,7 +67,8 @@ import { MouseEvent } from '../../events';
             [displayCheck]="displayCheck"
             [treeStatus]="group.treeStatus"
             (treeAction)="onTreeAction(group)"
-            (activate)="selector.onActivate($event, indexes.first + i)">
+            (activate)="selector.onActivate($event, indexes.first + i)"
+            (deactivate)="selector.onDeactivate($event, indexes.first + i)">
           </datatable-body-row>
           <ng-template #groupedRowsTemplate>
             <datatable-body-row
@@ -82,7 +84,8 @@ import { MouseEvent } from '../../events';
               [rowIndex]="getRowIndex(row)"
               [expanded]="getRowExpanded(row)"
               [rowClass]="rowClass"
-              (activate)="selector.onActivate($event, i)">
+              (activate)="selector.onActivate($event, i)"
+              (deactivate)="selector.onDeactivate($event, i)">
             </datatable-body-row>
           </ng-template>
         </datatable-row-wrapper>
@@ -210,6 +213,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   @Output() scroll: EventEmitter<any> = new EventEmitter();
   @Output() page: EventEmitter<any> = new EventEmitter();
   @Output() activate: EventEmitter<any> = new EventEmitter();
+  @Output() deactivate: EventEmitter<any> = new EventEmitter();
   @Output() select: EventEmitter<any> = new EventEmitter();
   @Output() detailToggle: EventEmitter<any> = new EventEmitter();
   @Output() rowContextmenu = new EventEmitter<{ event: MouseEvent, row: any }>(false);

--- a/src/components/body/selection.component.ts
+++ b/src/components/body/selection.component.ts
@@ -29,6 +29,7 @@ export class DataTableSelectionComponent {
   @Input() selectCheck: any;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
+  @Output() deactivate: EventEmitter<any> = new EventEmitter();
   @Output() select: EventEmitter<any> = new EventEmitter();
 
   prevIndex: number;
@@ -88,6 +89,10 @@ export class DataTableSelectionComponent {
       }
     }
     this.activate.emit(model);
+  }
+
+  onDeactivate(model: Model): void {
+    this.deactivate.emit(model);
   }
 
   onKeyboardFocus(model: Model): void {

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -83,6 +83,7 @@ import { BehaviorSubject, Subscription } from 'rxjs';
         [summaryPosition]="summaryPosition"
         (page)="onBodyPage($event)"
         (activate)="activate.emit($event)"
+        (deactivate)="deactivate.emit($event)"
         (rowContextmenu)="onRowContextmenu($event)"
         (select)="onBodySelect($event)"
         (scroll)="onBodyScroll($event)"
@@ -486,6 +487,11 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    * A cell or row was focused via keyboard or mouse click.
    */
   @Output() activate: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * A row was left with the mouse cursor.
+   */
+  @Output() deactivate: EventEmitter<any> = new EventEmitter();
 
   /**
    * A cell or row was selected.


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/swimlane/ngx-datatable/issues/404

At the moment there is no function that triggers on blur.

**What is the new behavior?**
Added the possibility to add a (deactivate) input on an item which will receive a function and will get triggered on the mouseleave event from a row.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No