### PR TITLE
Fixed datatable-row-wrapper getRowIndex Arg

### DIFF
--- a/demo/basic/row-detail.component.ts
+++ b/demo/basic/row-detail.component.ts
@@ -27,8 +27,12 @@ import { Component, ViewEncapsulation, ViewChild } from '@angular/core';
         [rows]='rows'
         (page)="onPage($event)">
         <!-- Row Detail Template -->
-        <ngx-datatable-row-detail [rowHeight]="100" #myDetailRow (toggle)="onDetailToggle($event)">
-          <ng-template let-row="row" let-expanded="expanded" ngx-datatable-row-detail-template>
+        <ngx-datatable-row-detail [rowHeight]="150" #myDetailRow (toggle)="onDetailToggle($event)">
+          <ng-template let-row="row" let-rowIndex="rowIndex" let-expanded="expanded" ngx-datatable-row-detail-template>
+          <div style="padding-left:35px;">
+              <div><strong>Index</strong></div>
+              <div>{{rowIndex}}</div>
+            </div>
             <div style="padding-left:35px;">
               <div><strong>Address</strong></div>
               <div>{{row.address.city}}, {{row.address.state}}</div>
@@ -81,7 +85,7 @@ import { Component, ViewEncapsulation, ViewChild } from '@angular/core';
 
 })
 export class RowDetailsComponent {
-
+  
   @ViewChild('myTable') table: any;
 
   rows: any[] = [];
@@ -120,5 +124,5 @@ export class RowDetailsComponent {
   onDetailToggle(event) {
     console.log('Detail Toggled', event);
   }
-
+  
 }

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -49,7 +49,7 @@ import { MouseEvent } from '../../events';
           [detailRowHeight]="getDetailRowHeight(group[i],i)"
           [row]="group"
           [expanded]="getRowExpanded(group)"
-          [rowIndex]="getRowIndex(group[i])"
+          [rowIndex]="getRowIndex(group)"
           (rowContextmenu)="rowContextmenu.emit($event)">
           <datatable-body-row
             *ngIf="!groupedRows; else groupedRowsTemplate"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
row detail has rowIndex of 0 


**What is the new behavior?**
fixes #992 #1385 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: Changed rowDetail demo to show rowIndex inside the row's detail.
