### PR TITLE
fix: trackByProp can't work.

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -263,7 +263,8 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     this.rowTrackingFn = function(this: any, index: number, row: any): any {
       const idx = this.getRowIndex(row);
       if (this.trackByProp) {
-        return `${idx}-${this.trackByProp}`;
+        return row[this.trackByProp];
+        // return `${idx}-${this.trackByProp}`;
       } else {
         return idx;
       }


### PR DESCRIPTION
trackByProp must be a 'guid'.

**What kind of change does this PR introduce?** (check one with "x")
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
use [trackByProp], the dom did't refresh.


**What is the new behavior?**
use [trackByProp], the dom can refresh by row prop change.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No