### PR TITLE
Fix issue that the loading indicator won't show when there's no row d…

### DIFF
--- a/demo/basic/basic-auto.component.ts
+++ b/demo/basic/basic-auto.component.ts
@@ -21,6 +21,7 @@ import { Component } from '@angular/core';
         [headerHeight]="50"
         [footerHeight]="50"
         [rowHeight]="'auto'"
+        [scrollbarH]="true"
         [reorderable]="reorderable">
       </ngx-datatable>
     </div>

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -101,6 +101,11 @@ import { MouseEvent } from '../../events';
         *ngIf="!rows?.length && !loadingIndicator"
         [innerHTML]="emptyMessage">
       </div>
+      <div
+        class="empty-row"
+        *ngIf="!rows?.length && loadingIndicator"
+        [innerHTML]="">
+      </div>
     </datatable-selection>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
…ata and scrollbarH is on.

**What kind of change does this PR introduce?** (check one with "x")
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When the table is emtpy and scrollbarH is true, loading indicator won't show.


**What is the new behavior?**
loading indiator will show


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Issue: https://github.com/swimlane/ngx-datatable/issues/1573