### PR TITLE
#1234: Updated the DataTableBodyComponent to handle scroller sizing i…

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -28,7 +28,7 @@ import { MouseEvent } from '../../events';
         [scrollbarV]="scrollbarV"
         [scrollbarH]="scrollbarH"
         [scrollHeight]="scrollHeight"
-        [scrollWidth]="columnGroupWidths?.total"
+        [scrollWidth]="_columnGroupWidths?.total"
         (scroll)="onBodyScroll($event)">
         <datatable-summary-row
           *ngIf="summaryRow && summaryPosition === 'top'"
@@ -128,12 +128,22 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   @Input() rowClass: any;
   @Input() groupedRows: any;
   @Input() groupExpansionDefault: boolean;
-  @Input() innerWidth: number;
   @Input() groupRowsBy: string;
   @Input() virtualization: boolean;
   @Input() summaryRow: boolean;
   @Input() summaryPosition: string;
   @Input() summaryHeight: number;
+
+  @Input() set innerWidth(val: number) {
+    this._innerWidth = val;
+    if (this.columns) {
+      this.recalculateColumnGroups();
+    }
+  }
+
+  get innerWidth(): number {
+    return this._innerWidth;
+  }
 
   @Input() set pageSize(val: number) {
     this._pageSize = val;
@@ -156,8 +166,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
 
   @Input() set columns(val: any[]) {
     this._columns = val;
-    const colsByPin = columnsByPin(val);
-    this.columnGroupWidths = columnGroupWidths(colsByPin, val);
+    this.recalculateColumnGroups();
   }
 
   get columns(): any[] {
@@ -241,8 +250,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   temp: any[] = [];
   offsetY: number = 0;
   indexes: any = {};
-  columnGroupWidths: any;
-  columnGroupWidthsWithoutGroup: any;
+  _columnGroupWidths: any;
   rowTrackingFn: any;
   listener: any;
   rowIndexes: any = new Map();
@@ -254,6 +262,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   _rowCount: number;
   _offset: number;
   _pageSize: number;
+  _innerWidth: number;
 
   /**
    * Creates an instance of DataTableBodyComponent.
@@ -421,6 +430,14 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Updates the column group data
+   */
+  recalculateColumnGroups(): void {
+    const colByPin = columnsByPin(this._columns);
+    this._columnGroupWidths = columnGroupWidths(colByPin, this._columns);
+  }
+
+  /**
    * Get the row height
    */
   getRowHeight(row: any): number {
@@ -496,7 +513,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
 
     // only add styles for the group if there is a group
     if (this.groupedRows) {
-      styles['width'] = this.columnGroupWidths.total;
+      styles['width'] = this._columnGroupWidths.total;
     }
 
     if (this.scrollbarV && this.virtualization) {
@@ -703,7 +720,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    * Gets the row pinning group styles
    */
   stylesByGroup(group: string) {
-    const widths = this.columnGroupWidths;
+    const widths = this._columnGroupWidths;
     const offsetX = this.offsetX;
 
     const styles = {


### PR DESCRIPTION
Some changes were taken from PR #1458  
The problem with this PR is that it also contains changes to the column width calculation that have undesired effects. 
So for fixing issue #1234 I took only the changes on body.component.ts.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** 
#1234  


**What is the new behavior?**
No empty space with fullscreen data table.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information**:
-