### PR TITLE
feature(config): implement global module config via forRoot

### DIFF
--- a/demo/module.ts
+++ b/demo/module.ts
@@ -126,7 +126,15 @@ import { SummaryRowInlineHtmlComponent } from './summary/summary-row-inline-html
     SummaryRowServerPagingComponent,
     SummaryRowInlineHtmlComponent,
   ],
-  imports: [BrowserModule, NgxDatatableModule],
+  imports: [BrowserModule,
+    NgxDatatableModule.forRoot({
+      messages: {
+        emptyMessage: 'No data to display',   // Message to show when array is presented, but contains no values
+        totalMessage: 'total',                // Footer total message
+        selectedMessage: 'selected'           // Footer selected message
+      }
+    })
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -3,7 +3,7 @@ import {
   HostListener, ContentChildren, OnInit, QueryList, AfterViewInit,
   HostBinding, ContentChild, TemplateRef, IterableDiffer,
   DoCheck, KeyValueDiffers, KeyValueDiffer, ViewEncapsulation,
-  ChangeDetectionStrategy, ChangeDetectorRef, SkipSelf, OnDestroy
+  ChangeDetectionStrategy, ChangeDetectorRef, SkipSelf, OnDestroy, Optional, Inject
 } from '@angular/core';
 
 import {
@@ -21,6 +21,7 @@ import { DatatableFooterDirective } from './footer';
 import { DataTableHeaderComponent } from './header';
 import { MouseEvent } from '../events';
 import { BehaviorSubject, Subscription } from 'rxjs';
+import {INgxDatatableConfig} from "../datatable.module";
 
 @Component({
   selector: 'ngx-datatable',
@@ -714,11 +715,17 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
     private cd: ChangeDetectorRef,
     element: ElementRef,
     differs: KeyValueDiffers,
-    private columnChangesService: ColumnChangesService) {
+    private columnChangesService: ColumnChangesService,
+    @Optional() @Inject('configuration') private configuration: INgxDatatableConfig) {
 
     // get ref to elm for measuring
     this.element = element.nativeElement;
     this.rowDiffer = differs.find({}).create();
+
+    // apply global settings from Module.forRoot
+    if (this.configuration && this.configuration.messages) {
+      this.messages = {...this.configuration.messages};
+    }
   }
 
   /**

--- a/src/datatable.module.ts
+++ b/src/datatable.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import {
@@ -95,4 +95,29 @@ import {
     DatatableGroupHeaderTemplateDirective
   ]
 })
-export class NgxDatatableModule { }
+export class NgxDatatableModule {
+
+  /**
+   * Configure global configuration via INgxDatatableConfig
+   * @param configuration
+   */
+  static forRoot(configuration: INgxDatatableConfig): ModuleWithProviders {
+    return {
+      ngModule: NgxDatatableModule,
+      providers: [
+        {provide: 'configuration', useValue: configuration },
+      ]
+    };
+  }
+}
+
+/**
+ * Interface definition for INgxDatatableConfig global configuration
+ */
+export interface INgxDatatableConfig {
+  messages: {
+    emptyMessage: string, // Message to show when array is presented, but contains no values
+    totalMessage: string, // Footer total message
+    selectedMessage: string // Footer selected message
+  };
+}


### PR DESCRIPTION
currently only the [messages] are supported

Change-Id: I772a95861ffa36353430123526a9f9e82fa0187e

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently the localization for the [messages] must be set in html for every ngx-datatable instance. 
An already existing Issue from @fantoine last year=> https://github.com/swimlane/ngx-datatable/issues/1602


**What is the new behavior?**
With this change, you can set the [messages] globally via `Module.forRoot`

```
// Import the Module with forRoot
NgxDatatableModule.forRoot({
      messages: {
        emptyMessage: 'No data to display',   // Message to show when array is presented, but contains no values
        totalMessage: 'total',                // Footer total message
        selectedMessage: 'selected'           // Footer selected message
      }
    })
```

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
