### PR TITLE
[Bugfix] Show rows after cleaning filter on scroll

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
@@ -11,6 +11,7 @@ import {
   KeyValueDiffers
 } from '@angular/core';
 import { MouseEvent } from '../../events';
+import { DatatableRowDetailDirective } from '../row-detail/row-detail.directive';
 
 @Component({
   selector: 'datatable-row-wrapper',
@@ -45,10 +46,10 @@ import { MouseEvent } from '../../events';
 })
 export class DataTableRowWrapperComponent implements DoCheck {
   @Input() innerWidth: number;
-  @Input() rowDetail: any;
+  @Input() rowDetail: DatatableRowDetailDirective;
   @Input() groupHeader: any;
   @Input() offsetX: number;
-  @Input() detailRowHeight: any;
+  @Input() detailRowHeight: number;
   @Input() row: any;
   @Input() groupedRows: any;
   @Output() rowContextmenu = new EventEmitter<{ event: MouseEvent; row: any }>(false);

--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
@@ -13,9 +13,11 @@ import {
 import { ScrollerComponent } from './scroller.component';
 import { MouseEvent } from '../../events';
 import { SelectionType } from '../../types/selection.type';
-import { columnsByPin, columnGroupWidths } from '../../utils/column';
+import { columnsByPin, columnGroupWidths, IColumnGroupWidths } from '../../utils/column';
 import { RowHeightCache } from '../../utils/row-height-cache';
 import { translateXY } from '../../utils/translate';
+import { Subscription } from 'rxjs';
+import { DatatableRowDetailDirective, IRowDetailToggle } from '../row-detail/row-detail.directive';
 
 @Component({
   selector: 'datatable-body',
@@ -130,7 +132,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   @Input() selectionType: SelectionType;
   @Input() selected: any[] = [];
   @Input() rowIdentity: any;
-  @Input() rowDetail: any;
+  @Input() rowDetail: DatatableRowDetailDirective;
   @Input() groupHeader: any;
   @Input() selectCheck: any;
   @Input() displayCheck: any;
@@ -158,6 +160,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     this._rows = val;
     this.rowExpansions.clear();
     this.recalcLayout();
+    this.offsetY = 0;
   }
 
   get rows(): any[] {
@@ -209,7 +212,6 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     } else {
       this._bodyHeight = 'auto';
     }
-
     this.recalcLayout();
   }
 
@@ -249,14 +251,14 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
 
   rowHeightsCache: RowHeightCache = new RowHeightCache();
   temp: any[] = [];
-  offsetY = 0;
-  indexes: any = {};
-  columnGroupWidths: any;
-  columnGroupWidthsWithoutGroup: any;
-  rowTrackingFn: any;
-  listener: any;
-  rowIndexes: any = new Map();
-  rowExpansions: any = new Map();
+  offsetY: number = 0;
+  indexes: { first: number, last: number } = { first: null, last: null };
+  columnGroupWidths: IColumnGroupWidths;
+  // columnGroupWidthsWithoutGroup: any; // Unused
+  rowTrackingFn: (index: number, row: any) => any;
+  listener: Subscription;
+  rowIndexes: Map<any, number> = new Map();
+  rowExpansions: Map<any, any> = new Map();
 
   _rows: any[];
   _bodyHeight: any;
@@ -285,7 +287,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    */
   ngOnInit(): void {
     if (this.rowDetail) {
-      this.listener = this.rowDetail.toggle.subscribe(({ type, value }: { type: string; value: any }) => {
+      this.listener = this.rowDetail.toggle.subscribe(({ type, value }: IRowDetailToggle) => {
         if (type === 'row') {
           this.toggleRowExpansion(value);
         }
@@ -511,7 +513,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    *
    * @memberOf DataTableBodyComponent
    */
-  getRowsStyles(rows: any): any {
+  getRowsStyles = (rows: any): any => {
     const styles: any = {};
 
     // only add styles for the group if there is a group
@@ -534,10 +536,8 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
       // The position of this row would be the sum of all row heights
       // until the previous row position.
       const pos = this.rowHeightsCache.query(idx - 1);
-
       translateXY(styles, 0, pos);
     }
-
     return styles;
   }
 

--- a/projects/swimlane/ngx-datatable/src/lib/components/row-detail/row-detail.directive.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/row-detail/row-detail.directive.ts
@@ -1,6 +1,11 @@
 import { Input, Output, EventEmitter, Directive, TemplateRef, ContentChild } from '@angular/core';
 import { DatatableRowDetailTemplateDirective } from './row-detail-template.directive';
 
+export interface IRowDetailToggle {
+  type: string;
+  value: any;
+}
+
 @Directive({ selector: 'ngx-datatable-row-detail' })
 export class DatatableRowDetailDirective {
   /**
@@ -22,7 +27,7 @@ export class DatatableRowDetailDirective {
   /**
    * Row detail row visbility was toggled.
    */
-  @Output() toggle: EventEmitter<any> = new EventEmitter();
+  @Output() toggle: EventEmitter<IRowDetailToggle> = new EventEmitter();
 
   /**
    * Toggle the expansion of the row

--- a/projects/swimlane/ngx-datatable/src/lib/utils/column.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/utils/column.ts
@@ -1,8 +1,26 @@
+export interface IColumnsPin {
+  left: any[];
+  center: any[];
+  right: any[];
+}
+
+export interface IColumnsPinArray {
+  type: string;
+  columns: any[];
+}
+
+export interface IColumnGroupWidths {
+  left: number;
+  center: number;
+  right: number;
+  total: number;
+}
+
 /**
  * Returns the columns by pin.
  */
-export function columnsByPin(cols: any[]) {
-  const ret: { left: any; center: any; right: any } = {
+export function columnsByPin(cols: any[]): IColumnsPin {
+  const ret: IColumnsPin = {
     left: [],
     center: [],
     right: []
@@ -26,7 +44,7 @@ export function columnsByPin(cols: any[]) {
 /**
  * Returns the widths of all group sets of a column
  */
-export function columnGroupWidths(groups: any, all: any) {
+export function columnGroupWidths(groups: any, all: any): IColumnGroupWidths {
   return {
     left: columnTotalWidth(groups.left),
     center: columnTotalWidth(groups.center),
@@ -38,7 +56,7 @@ export function columnGroupWidths(groups: any, all: any) {
 /**
  * Calculates the total width of all columns and their groups
  */
-export function columnTotalWidth(columns: any[], prop?: string) {
+export function columnTotalWidth(columns: any[], prop?: string): number {
   let totalWidth = 0;
 
   if (columns) {
@@ -55,7 +73,7 @@ export function columnTotalWidth(columns: any[], prop?: string) {
 /**
  * Calculates the total width of all columns and their groups
  */
-export function columnsTotalWidth(columns: any, prop?: any) {
+export function columnsTotalWidth(columns: any, prop?: any): number {
   let totalWidth = 0;
 
   for (const column of columns) {
@@ -66,13 +84,13 @@ export function columnsTotalWidth(columns: any, prop?: any) {
   return totalWidth;
 }
 
-export function columnsByPinArr(val: any) {
-  const colsByPinArr = [];
-  const colsByPin = columnsByPin(val);
+export function columnsByPinArr(val: any): IColumnsPinArray[] {
+  const colsByPinArr: IColumnsPinArray[] = [];
+  const colsByPin: IColumnsPin = columnsByPin(val);
 
-  colsByPinArr.push({ type: 'left', columns: colsByPin['left'] });
-  colsByPinArr.push({ type: 'center', columns: colsByPin['center'] });
-  colsByPinArr.push({ type: 'right', columns: colsByPin['right'] });
+  colsByPinArr.push({ type: 'left', columns: colsByPin.left });
+  colsByPinArr.push({ type: 'center', columns: colsByPin.center });
+  colsByPinArr.push({ type: 'right', columns: colsByPin.right });
 
   return colsByPinArr;
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Fixes #1331 and #1449


**What is the new behavior?**
Reset to zero the `offsetY` property after rows calculation so the transform style is properly set. Also this PR include minor typings in order to better debugging for future bugfixes.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No
