### PR TITLE
Fix selectCheck-based filter

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.spec.ts
@@ -392,6 +392,35 @@ describe('DatatableComponent With Custom Templates', () => {
   });
 });
 
+describe('DatatableComponent With CheckBox Selection', () => {
+  beforeEach(async(() => setupTest(TestFixtureComponentWithCheckBoxSelection)));
+
+  it('should filter unselectable rows', () => {
+    const initialRows = [{ id: 5 }, { id: 20 }, { id: 12 }];
+    const columns = [
+      {
+        prop: 'id'
+      }
+    ];
+
+    const selectCheck = (row) => row.id !==5;
+
+    component.columns = columns;
+    component.rows = initialRows;
+    component.selectCheck = selectCheck;
+
+    fixture.detectChanges();
+    selectAll();
+    fixture.detectChanges();
+
+    const datatableComponent = fixture.debugElement.query(By.directive(DatatableComponent)).componentInstance;
+
+    expect(datatableComponent.selected).toBeTruthy();
+    expect(datatableComponent.selected.length).toBe(2);
+  });
+});
+
+
 @Component({
   template: `
     <ngx-datatable [columns]="columns" [rows]="rows" [sorts]="sorts"> </ngx-datatable>
@@ -431,6 +460,24 @@ class TestFixtureComponentWithCustomTemplates {
   columnTwoProp: string;
 }
 
+@Component({
+  template: `
+    <ngx-datatable [rows]="rows" 
+                   [columns]="columns" 
+                   [selectionType]="'checkbox'"
+                   [selectCheck]="selectCheck">
+      <ngx-datatable-column [headerCheckboxable]="true" [checkboxable]="true">
+      </ngx-datatable-column>
+    </ngx-datatable>
+  `
+})
+class TestFixtureComponentWithCheckBoxSelection {
+  columns: any[] = [];
+  rows: any[] = [];
+  selectCheck: any = (row) => true;
+}
+
+
 function setupTest(componentClass) {
   return TestBed.configureTestingModule({
     declarations: [componentClass],
@@ -464,4 +511,11 @@ function textContent({ row, column }: { row: number; column: number }) {
   const bodyCellDe = bodyRowDe.queryAll(By.directive(DataTableBodyCellComponent))[columnIndex];
 
   return bodyCellDe.nativeElement.textContent;
+}
+
+function selectAll() {
+  const columnIndex = 0;
+  const headerCellDe = fixture.debugElement.queryAll(By.css('datatable-header-cell'))[columnIndex];
+  const de = headerCellDe.query(By.css('input[type="checkbox"]'));
+  de.triggerEventHandler('change', null);
 }

--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
@@ -606,15 +606,24 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    * Returns if all rows are selected.
    */
   get allRowsSelected(): boolean {
-    let allRowsSelected = this.rows && this.selected && this.selected.length === this.rows.length;
+    let eligibleForSelection = this.rows;
+
+    if (eligibleForSelection && this.selectCheck)
+      eligibleForSelection = eligibleForSelection.filter(this.selectCheck.bind(this));
+      
+    let allRowsSelected = (eligibleForSelection && this.selected && this.selected.length === eligibleForSelection.length);
 
     if (this.selectAllRowsOnPage) {
       const indexes = this.bodyComponent.indexes;
-      const rowsOnPage = indexes.last - indexes.first;
-      allRowsSelected = this.selected.length === rowsOnPage;
+      let eligibleForSelectionOnPage = this._internalRows.slice(indexes.first, indexes.last);
+
+      if (this.selectCheck)
+        eligibleForSelectionOnPage = eligibleForSelectionOnPage.filter(this.selectCheck.bind(this));
+
+      allRowsSelected = (this.selected.length === eligibleForSelectionOnPage.length);
     }
 
-    return this.selected && this.rows && this.rows.length !== 0 && allRowsSelected;
+    return this.selected && eligibleForSelection && eligibleForSelection.length !== 0 && allRowsSelected;
   }
 
   element: HTMLElement;
@@ -1083,23 +1092,33 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
       // before we splice, chk if we currently have all selected
       const first = this.bodyComponent.indexes.first;
       const last = this.bodyComponent.indexes.last;
-      const allSelected = this.selected.length === last - first;
+      let eligibleForSelectionOnPage = this._internalRows.slice(first, last);
+
+      if (this.selectCheck)
+        eligibleForSelectionOnPage = eligibleForSelectionOnPage.filter(this.selectCheck.bind(this));
+
+      const allSelected = eligibleForSelectionOnPage && this.selected.length === eligibleForSelectionOnPage.length;
 
       // remove all existing either way
       this.selected = [];
 
       // do the opposite here
       if (!allSelected) {
-        this.selected.push(...this._internalRows.slice(first, last));
+        this.selected.push(...eligibleForSelectionOnPage);
       }
     } else {
+
+      let eligibleForSelection = this.rows;
+      if (this.selectCheck)
+          eligibleForSelection = eligibleForSelection.filter(this.selectCheck.bind(this));
+
       // before we splice, chk if we currently have all selected
-      const allSelected = this.selected.length === this.rows.length;
+      const allSelected = eligibleForSelection && this.selected.length === eligibleForSelection.length;
       // remove all existing either way
       this.selected = [];
       // do the opposite here
       if (!allSelected) {
-        this.selected.push(...this.rows);
+        this.selected.push(...eligibleForSelection);
       }
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When selecting the "Select all" checkbox in the table header, selectCheck-filter is ignored.
The "Select all" can select all the items no matter the item is checkable or not.

I think it`s a bug.

I found similar issues, but unanswered.
https://github.com/swimlane/ngx-datatable/issues/889
https://github.com/swimlane/ngx-datatable/pull/1437

**What is the new behavior?**

If I select the "Select all" option in the table header, the selectCheck should be called for every row.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: