### PR TITLE
Fix clearTimeout / _destroySubscription race

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/directives/long-press.directive.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/directives/long-press.directive.ts
@@ -107,6 +107,7 @@ export class LongPressDirective implements OnDestroy {
   }
 
   ngOnDestroy(): void {
+    clearTimeout(this.timeout);
     this._destroySubscription();
   }
 


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check one with "x")
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Before this patch, when an Angular component gets destroyed (e.g. for
recreation by parent) while a long-click is in progress, a TypeError
could be thrown on line 59 because `this.subscription` could already
have been unset.


**What is the new behavior?**

ngx-datatable doesn't crash anymore

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
