### PR TITLE
Guard setStylesByGroup if columns not yet set

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/header/header.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/header/header.component.ts
@@ -300,6 +300,10 @@ export class DataTableHeaderComponent {
   }
 
   setStylesByGroup() {
+    if (!this._columnGroupWidths) {
+      return;
+    }
+
     this._styleByGroup.left = this.calcStylesByGroup('left');
     this._styleByGroup.center = this.calcStylesByGroup('center');
     this._styleByGroup.right = this.calcStylesByGroup('right');


### PR DESCRIPTION
If you call calcStylesByGroup before the `columns` Input is set, `this._columnGroupWidths` will be undefined and the component will throw an error. Specifically the `offsetX` input unconditionally calls `calcStylesByGroup` and will fail in the upcoming version of Angular because the input order changes in Ivy. Inputs should avoid depending on other inputs as much as possible or guard against unexpected input orders.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Component throws an error in Angular Ivy if offsetX is bound before columns
