### PR TITLE
ngx-datatable-tree-toggle directive is not working

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/utils/column-helper.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/utils/column-helper.ts
@@ -99,6 +99,10 @@ export function translateTemplates(templates: DataTableColumnDirective[]): any[]
     if (temp.cellTemplate) {
       col.cellTemplate = temp.cellTemplate;
     }
+    
+    if (temp.treeToggleTemplate) {
+      col.treeToggleTemplate = temp.treeToggleTemplate;
+    }
 
     if (temp.summaryFunc) {
       col.summaryFunc = temp.summaryFunc;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

if you use **ngx-datatable-tree-toggle directive** datatable always used default button
because column.treeToggleTemplate was not setup

**What is the new behavior?**

setting treeToggleTemplate when is directive used


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No
