### PR TITLE
Protect detectChanges in a destroyed view

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/header/header.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/header/header.component.ts
@@ -5,7 +5,8 @@ import {
   Input,
   HostBinding,
   ChangeDetectorRef,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
+  ViewRef
 } from '@angular/core';
 import { MouseEvent } from '../../events';
 import { columnsByPin, columnGroupWidths, columnsByPinArr } from '../../utils/column';
@@ -303,7 +304,9 @@ export class DataTableHeaderComponent {
     this._styleByGroup.left = this.calcStylesByGroup('left');
     this._styleByGroup.center = this.calcStylesByGroup('center');
     this._styleByGroup.right = this.calcStylesByGroup('right');
-    this.cd.detectChanges();
+    if (!(this.cd as ViewRef).destroyed) {
+      this.cd.detectChanges();
+    }
   }
 
   calcStylesByGroup(group: string): any {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**

Force detectChanges in setStylesByGroup() header component introduces a detectChanges crash when you destroy the table while it is loading (Angular 8, it is not happening in Angular 6)

**What is the new behavior?**

Check if the header view exist to do a safe detectChanges

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No