### PR TITLE
Fix: refresh virtual grid after scroll

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
@@ -370,6 +370,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     this.updateIndexes();
     this.updatePage(event.direction);
     this.updateRows();
+    this.cd.detectChanges();
   }
 
   /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Virtual grid with variable height rows is not repainted after scrolling, or repaint is delayed.

**What is the new behavior?**
Repainting/refreshing happens right away.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
This is very old bug, I hope you can accept this fix soon. I need to patch the lib on the fly for the time being to make grid refresh itself.
