### PR TITLE
Fix column width recalculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 .idea
 yarn.lock
 /.vscode
+/.vs

--- a/projects/swimlane/ngx-datatable/src/lib/utils/math.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/utils/math.spec.ts
@@ -14,7 +14,7 @@ describe('Math function', () => {
 
         expect(columns[0].width).toBe(250); // Not changed
         expect(columns[1].width).toBe(400);
-        expect(columns[2].width).toBe(250);
+        expect(columns[2].width).toBe(100);
       });
     });
 

--- a/projects/swimlane/ngx-datatable/src/lib/utils/math.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/utils/math.ts
@@ -109,12 +109,13 @@ export function forceFillColumnWidths(
   let exceedsWindow = false;
   let contentWidth = getContentWidth(allColumns, defaultColWidth);
   let remainingWidth = expectedWidth - contentWidth;
+  let columnsToResizeLength = columnsToResize.length;
   const columnsProcessed: any[] = [];
   const remainingWidthLimit = 1; // when to stop
 
   // This loop takes care of the
   do {
-    additionWidthPerColumn = remainingWidth / columnsToResize.length;
+    additionWidthPerColumn = remainingWidth / columnsToResizeLength;
     exceedsWindow = contentWidth >= expectedWidth;
 
     for (const column of columnsToResize) {
@@ -126,14 +127,22 @@ export function forceFillColumnWidths(
         if (column.minWidth && newSize < column.minWidth) {
           column.width = column.minWidth;
           columnsProcessed.push(column);
+          columnsToResizeLength--;
         } else if (column.maxWidth && newSize > column.maxWidth) {
           column.width = column.maxWidth;
           columnsProcessed.push(column);
-        } else {
-          column.width = newSize;
+          columnsToResizeLength--;
         }
       }
+      column.width = Math.max(0, column.width);
+    }
 
+    additionWidthPerColumn = remainingWidth / columnsToResizeLength;
+    for (const column of columnsToResize) {
+      const newSize = (column.width || defaultColWidth) + additionWidthPerColumn;
+      if (!column.minWidth && !column.maxWidth) {
+        column.width = newSize;
+      }
       column.width = Math.max(0, column.width);
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Problem: When reducing the size of the browser window, the rightmost column(s) are sometime not visible. Resizing the window larger and smaller causes the columns to be recalculated. The user may have to repeat this several times until the columns are correct.

Probably cause: When calculating the column widths, it is always based on the total width of all columns:
additionWidthPerColumn = remainingWidth / columnsToResize.length;

Columns with minWidth or maxWidth are set to their defined value:
column.width = column.minWidth;
column.width = column.maxWidth;

Only columns without minWidth or maxWidth are recalculated:
newSize = (column.width || defaultColWidth) + additionWidthPerColumn;
…
column.width = newSize;


**What is the new behavior?**

To fix this, the total width to be portioned out should only be used for columns can be resized (i.e. have a recalculated newSize).

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
