### PR TITLE
Fixed source code link for demos :pencil:

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -22,7 +22,7 @@
       * [Outputs](api/detail/outputs.md)
 * Demos
     * [Online](http://swimlane.github.io/ngx-datatable/)
-    * [Source Code](https://github.com/swimlane/ngx-datatable/tree/master/demo)
+    * [Source Code](https://github.com/swimlane/ngx-datatable/tree/master/src/app)
 * Contributing
    * [Building](contributing/building.md)
    * [Guidelines](contributing/guidelines.md)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
In [demos](https://swimlane.gitbook.io/ngx-datatable/demos) the source code link is incorrect it redirects to : https://github.com/swimlane/ngx-datatable/tree/master/demo (page not found)


**What is the new behavior?**
Now it redirects to https://github.com/swimlane/ngx-datatable/tree/master/src/app which have the source code for the examples.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
