### PR TITLE
Fix loadingIndicator is scrolled away

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
@@ -19,6 +19,7 @@ import { translateXY } from '../../utils/translate';
 @Component({
   selector: 'datatable-body',
   template: `
+    <datatable-progress *ngIf="loadingIndicator"> </datatable-progress>
     <datatable-selection
       #selector
       [selected]="selected"
@@ -30,7 +31,6 @@ import { translateXY } from '../../utils/translate';
       (select)="select.emit($event)"
       (activate)="activate.emit($event)"
     >
-      <datatable-progress *ngIf="loadingIndicator"> </datatable-progress>
       <datatable-scroller
         *ngIf="rows?.length"
         [scrollbarV]="scrollbarV"

--- a/projects/swimlane/ngx-datatable/src/lib/themes/material.scss
+++ b/projects/swimlane/ngx-datatable/src/lib/themes/material.scss
@@ -251,6 +251,8 @@ $datatable-summary-row-background-hover: #ddd !default;
 	 * Body Styles
 	 */
   .datatable-body {
+    position: relative;
+
     .datatable-row-detail {
       background: $datatable-row-detail-background;
       padding: 10px;
@@ -292,12 +294,12 @@ $datatable-summary-row-background-hover: #ddd !default;
 
     .progress-linear {
       display: block;
-      position: relative;
+      position: sticky;
       width: 100%;
       height: 5px;
       padding: 0;
       margin: 0;
-      position: absolute;
+      top: 0;
 
       .container {
         display: block;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When using virtual scrolling, the loading bar is fixed at the bottom and only shows on last page.


**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
