### PR TITLE
fix: Type "checkbox" is not assignable to type SelectionType #1873

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
@@ -274,7 +274,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    * For no selection pass a `falsey`.
    * Default value: `undefined`
    */
-  @Input() selectionType: SelectionType;
+  @Input() selectionType: SelectionType | keyof typeof SelectionType;
 
   /**
    * Enable/Disable ability to re-order columns


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/swimlane/ngx-datatable/issues/1873

**What is the new behavior?**
you can use  `[selectionType]="'checkbox'"`

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
