### PR TITLE
Can't use custom Tree Toggle Template because of `ng-template`

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -45,12 +45,12 @@ export type TreeStatus = 'collapsed' | 'expanded' | 'loading' | 'disabled';
             <i *ngIf="treeStatus === 'expanded' || treeStatus === 'disabled'" class="icon datatable-icon-down"></i>
           </span>
         </button>
-        <ng-component
+        <ng-container
           *ngIf="column.treeToggleTemplate"
           [ngTemplateOutlet]="column.treeToggleTemplate"
           [ngTemplateOutletContext]="{ cellContext: cellContext }"
         >
-        </ng-component>
+        </ng-container>
       </ng-container>
 
       <span *ngIf="!column.cellTemplate" [title]="sanitizedValue" [innerHTML]="value"> </span>

--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -45,12 +45,12 @@ export type TreeStatus = 'collapsed' | 'expanded' | 'loading' | 'disabled';
             <i *ngIf="treeStatus === 'expanded' || treeStatus === 'disabled'" class="icon datatable-icon-down"></i>
           </span>
         </button>
-        <ng-template
+        <ng-component
           *ngIf="column.treeToggleTemplate"
           [ngTemplateOutlet]="column.treeToggleTemplate"
           [ngTemplateOutletContext]="{ cellContext: cellContext }"
         >
-        </ng-template>
+        </ng-component>
       </ng-container>
 
       <span *ngIf="!column.cellTemplate" [title]="sanitizedValue" [innerHTML]="value"> </span>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**   
 When using a custom Template Tree Toggle (`treeToggleTemplate` for a Column) it throws an error: " templateRef.createEmbeddedView is not a function"

**What is the new behavior?**    
The error doesn't happen, since we are using an `ng-container` instead of an `ng-template`

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
