### PR TITLE
Fixed invalid argument when rowHeight is a function

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
@@ -56,10 +56,10 @@ import { translateXY } from '../../utils/translate';
           [rowDetail]="rowDetail"
           [groupHeader]="groupHeader"
           [offsetX]="offsetX"
-          [detailRowHeight]="getDetailRowHeight(group && group[i], i)"
+          [detailRowHeight]="getDetailRowHeight(groupedRows ? group[i] : group, i)"
           [row]="group"
           [expanded]="getRowExpanded(group)"
-          [rowIndex]="getRowIndex(group && group[i])"
+          [rowIndex]="getRowIndex(groupedRows ? group[i] : group)"
           (rowContextmenu)="rowContextmenu.emit($event)"
         >
           <datatable-body-row


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When rowHeight is passed as a function to ngx-datatable-row-detail, it is called with the parameter row undefined, which makes it impossible to dynamically calculate height of row detail based on row data.

This is happening because when rows are not grouped, method getDetailRowHeight of datatable-body is called incorrectly.

**What is the new behavior?**

When rowHeight is a function it is called with the current row as the parameter.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

**Other information**:
