### PR TITLE
fixes calculation of scrollbar width when window scrollbar appears

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/scroller.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/scroller.component.ts
@@ -9,7 +9,8 @@ import {
   OnInit,
   OnDestroy,
   HostBinding,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
+  HostListener
 } from '@angular/core';
 
 import { MouseEvent } from '../../events';
@@ -48,6 +49,21 @@ export class ScrollerComponent implements OnInit, OnDestroy {
 
   constructor(private ngZone: NgZone, element: ElementRef, private renderer: Renderer2) {
     this.element = element.nativeElement;
+  }
+
+  /**
+   * Decrease scrollWidth by window scrollbar width.
+   *
+   * If browser window scrollbar appears, method reduces scrollWidth for a width of that scrollbar
+   */
+  @HostListener('window:resize')
+  onWindowResize() {
+    if (this.scrollbarV || this.scrollbarH) {
+      const diff = window.innerWidth - document.body.offsetWidth;
+      if (document.documentElement.scrollHeight !== document.documentElement.clientHeight) {
+        this.scrollWidth = this.scrollWidth - diff;
+      }
+    }
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
- If the window vertical scrollbar appears after table is created, horizontal scrollbar appears because datatable-scroller keeps same width as it was before scrollbar.

**What is the new behavior?**
Horizontal scrollbar should not be set because window vertical scrollbar appeared.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
