### PR TITLE
Fix expanding all the groups when the last group is collapsed by user

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.spec.ts
@@ -128,4 +128,29 @@ describe('DataTableBodyComponent', () => {
       expect(styles).toBeDefined();
     });
   });
+
+  describe('Row Grouping', () => {
+    it('should all group have collapsed state when all group are collapsed by user', () => {
+      component.groupExpansionDefault = true;
+      const rows = [
+        { name: 'Schroeder Mathews', gender: 'male', company: 'Polarium', age: 67 },
+        { name: 'Lynda Mendoza', gender: 'female', company: 'Dogspa', age: 10 }
+      ];
+      const [firstRow, secondRow] = rows;
+      component.rows = [...rows];
+      component.groupRowsBy = 'age';
+      component.rowIdentity = (x: any) => {
+        if (component.groupRowsBy) {
+          // each group in groupedRows are stored as {key, value: [rows]},
+          // where key is the groupRowsBy index
+          return x.key;
+        } else {
+          return x;
+        }
+      };
+      component.toggleRowExpansion(firstRow);
+      component.toggleRowExpansion(secondRow);
+      expect(component.isAllGroupCollapsed).toEqual(true);
+    });
+  });
 });

--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
@@ -255,6 +255,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   listener: any;
   rowIndexes: any = new WeakMap<any, string>();
   rowExpansions: any[] = [];
+  isAllGroupCollapsed: boolean;
 
   _rows: any[];
   _bodyHeight: any;
@@ -688,6 +689,9 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
       this.rowExpansions.push(row);
     }
 
+    // To identify if all group is collapsed
+    this.isAllGroupCollapsed = this.rowExpansions.length === 0;
+
     this.detailToggle.emit({
       rows: [row],
       currentIndex: viewPortFirstRowIndex
@@ -766,7 +770,8 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    * Returns if the row was expanded and set default row expansion when row expansion is empty
    */
   getRowExpanded(row: any): boolean {
-    if (this.rowExpansions.length === 0 && this.groupExpansionDefault) {
+    // By default, expand all groups. But avoid expanding all the groups when all the groups are collapsed by user
+    if (this.rowExpansions.length === 0 && this.groupExpansionDefault && !this.isAllGroupCollapsed) {
       for (const group of this.groupedRows) {
         this.rowExpansions.push(group);
       }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
All groups expand when closing the last expanded group #1946 

**What is the new behavior?**
Fix expanding all the groups when all the groups are collapsed by the user.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
