### PR TITLE
feat: conditionally apply checked class to checkbox label

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -29,6 +29,7 @@ export type TreeStatus = 'collapsed' | 'expanded' | 'loading' | 'disabled';
       <label
         *ngIf="column.checkboxable && (!displayCheck || displayCheck(row, column, value))"
         class="datatable-checkbox"
+        [class.checked]="isSelected"
       >
         <input type="checkbox" [checked]="isSelected" (click)="onCheckboxChange($event)" />
       </label>

--- a/projects/swimlane/ngx-datatable/src/lib/components/header/header-cell.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/header/header-cell.component.ts
@@ -24,7 +24,7 @@ import { SortDirection } from '../../types/sort-direction.type';
         [ngTemplateOutletContext]="targetMarkerContext"
       >
       </ng-template>
-      <label *ngIf="isCheckboxable" class="datatable-checkbox">
+      <label *ngIf="isCheckboxable" class="datatable-checkbox" [class.checked]="allRowsSelected">
         <input type="checkbox" [checked]="allRowsSelected" (change)="select.emit(!allRowsSelected)" />
       </label>
       <span *ngIf="!column.headerTemplate" class="datatable-header-cell-wrapper">


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
For proper individual styling of the checkbox (including the checked state), the surrounding `label` needs to know about the checked state of the `input` element.

**What is the new behavior?**
A 'checked' class conditionally gets added to the `label`, making it possible to take this state into account when using individual styling, e.g. when hiding the `input` and simulating its appearance with pseudo selectors on the `label`.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
