### PR TITLE
feat: change datatable checkbox to offer advanced styling options

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -26,12 +26,16 @@ export type TreeStatus = 'collapsed' | 'expanded' | 'loading' | 'disabled';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="datatable-body-cell-label" [style.margin-left.px]="calcLeftMargin(column, row)">
-      <label
-        *ngIf="column.checkboxable && (!displayCheck || displayCheck(row, column, value))"
-        class="datatable-checkbox"
-      >
-        <input type="checkbox" [checked]="isSelected" (click)="onCheckboxChange($event)" />
-      </label>
+      <ng-container *ngIf="column.checkboxable && (!displayCheck || displayCheck(row, column, value))">
+        <input
+          type="checkbox"
+          class="datatable-checkbox"
+          [checked]="isSelected"
+          (click)="onCheckboxChange($event)"
+          [attr.id]="checkboxId"
+        />
+        <label [attr.for]="checkboxId"></label>
+      </ng-container>
       <ng-container *ngIf="column.isTreeColumn">
         <button
           *ngIf="!column.treeToggleTemplate"
@@ -164,6 +168,10 @@ export class DataTableBodyCellComponent implements DoCheck, OnDestroy {
 
   get treeStatus(): TreeStatus {
     return this._treeStatus;
+  }
+
+  get checkboxId(): string {
+    return `checkbox_${this.rowIndex}_${this.column.$$id}`;
   }
 
   @Output() activate: EventEmitter<any> = new EventEmitter();

--- a/projects/swimlane/ngx-datatable/src/lib/components/header/header-cell.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/header/header-cell.component.ts
@@ -24,9 +24,16 @@ import { SortDirection } from '../../types/sort-direction.type';
         [ngTemplateOutletContext]="targetMarkerContext"
       >
       </ng-template>
-      <label *ngIf="isCheckboxable" class="datatable-checkbox">
-        <input type="checkbox" [checked]="allRowsSelected" (change)="select.emit(!allRowsSelected)" />
-      </label>
+      <ng-container *ngIf="isCheckboxable">
+        <input
+          type="checkbox"
+          class="datatable-checkbox"
+          [checked]="allRowsSelected"
+          (change)="select.emit(!allRowsSelected)"
+          [attr.id]="checkboxId"
+        />
+        <label [attr.for]="checkboxId"></label>
+      </ng-container>
       <span *ngIf="!column.headerTemplate" class="datatable-header-cell-wrapper">
         <span class="datatable-header-cell-label draggable" (click)="onSort()" [innerHTML]="name"> </span>
       </span>
@@ -74,6 +81,10 @@ export class DataTableHeaderCellComponent {
 
   get column(): TableColumn {
     return this._column;
+  }
+
+  get checkboxId(): string {
+    return `checkbox_${this.column.$$id}`;
   }
 
   @HostBinding('style.height.px')

--- a/projects/swimlane/ngx-datatable/src/lib/themes/material.scss
+++ b/projects/swimlane/ngx-datatable/src/lib/themes/material.scss
@@ -413,53 +413,58 @@ $datatable-summary-row-background-hover: #ddd !default;
  * Checkboxes
 **/
 .datatable-checkbox {
-  position: relative;
-  margin: 0;
-  cursor: pointer;
-  vertical-align: middle;
-  display: inline-block;
-  box-sizing: border-box;
-  padding: 0;
+  position: absolute;
+  left: -9999px;
+  opacity: 0;
 
-  input[type='checkbox'] {
+  &:checked {
+    ~ label {
+      &::after {
+        transform: translateY(2px) rotate(-45deg) scale(0.9);
+        height: 0.5rem;
+        border-color: #009688;
+        border-top-style: none;
+        border-right-style: none;
+      }
+    }
+  }
+
+  &:disabled {
+    ~ label {
+      cursor: not-allowed;
+      pointer-events: none;
+      opacity: 0.5;
+    }
+  }
+
+  ~ label {
+    display: inline-flex;
     position: relative;
+    top: 2px;
+    width: 1rem;
+    height: 1rem;
     margin: 0 1rem 0 0;
     cursor: pointer;
-    outline: none;
+    pointer-events: auto;
 
-    &:before {
-      -webkit-transition: all 0.3s ease-in-out;
-      -moz-transition: all 0.3s ease-in-out;
-      transition: all 0.3s ease-in-out;
-      content: '';
+    // visual checkbox clone and its checkmark
+    &::before,
+    &::after {
       position: absolute;
-      left: 0;
-      z-index: 1;
-      width: 1rem;
-      height: 1rem;
+      content: '';
+      width: inherit;
+      height: inherit;
+    }
+
+    // visual checkbox clone
+    &::before {
+      background-color: #fff;
+    }
+
+    // checkmark
+    &::after {
       border: 2px solid #f2f2f2;
-    }
-
-    &:checked:before {
-      -webkit-transform: rotate(-45deg);
-      -moz-transform: rotate(-45deg);
-      -ms-transform: rotate(-45deg);
-      transform: rotate(-45deg);
-      height: 0.5rem;
-      border-color: #009688;
-      border-top-style: none;
-      border-right-style: none;
-    }
-
-    &:after {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 1rem;
-      height: 1rem;
-      background: #fff;
-      cursor: pointer;
+      transition: all 0.3s ease-in-out;
     }
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently, the datatable´s checkbox makes use of pseudo elements (`::before` and `::after`) on the `input` element for styling reasons, which is not supported by all browsers.

**What is the new behavior?**
With the new approach, the template outputting the checkbox in the header or body cells is slightly modified along with the corresponding CSS, so that now the pseudo elements are defined on the `label` element, whereas the native `input` element is made invisible, yet providing its checked and disabled state etc.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
