### PR TITLE
If no groups, pass row to `getDetailRowHeight`

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
@@ -56,7 +56,7 @@ import { translateXY } from '../../utils/translate';
           [rowDetail]="rowDetail"
           [groupHeader]="groupHeader"
           [offsetX]="offsetX"
-          [detailRowHeight]="getDetailRowHeight(group && group[i], i)"
+          [detailRowHeight]="getDetailRowHeight(!groupedRows ? group : group && group[i], i)"
           [row]="group"
           [expanded]="getRowExpanded(group)"
           [rowIndex]="getRowIndex(group && group[i])"


### PR DESCRIPTION
If there are no groups in the data, `getDetailRowHeight` will receive `undefined` or garbage if `group[i]` exists.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
`getDetailRowHeight` is called with undefined (or garbage) if there are no groups.

**What is the new behavior?**
`getDetailRowHeight` is called with row if there are no groups.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No (I hope not)

If this PR contains a breaking change, please describe the impact and migration path for existing applications: 

**Other information**:
