### PR TITLE
When changing the scrollH/scrollV options, ensure that eventListeners are added/removed

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/scroller.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/scroller.component.ts
@@ -9,7 +9,9 @@ import {
   OnInit,
   OnDestroy,
   HostBinding,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
+  OnChanges,
+  SimpleChanges
 } from '@angular/core';
 
 import { MouseEvent } from '../../events';
@@ -22,7 +24,7 @@ import { MouseEvent } from '../../events';
   },
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ScrollerComponent implements OnInit, OnDestroy {
+export class ScrollerComponent implements OnInit, OnDestroy, OnChanges {
   @Input() scrollbarV: boolean = false;
   @Input() scrollbarH: boolean = false;
 
@@ -64,6 +66,14 @@ export class ScrollerComponent implements OnInit, OnDestroy {
     if (this._scrollEventListener) {
       this.parentElement.removeEventListener('scroll', this._scrollEventListener);
       this._scrollEventListener = null;
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['scrollbarV'] || changes['scrollbarH']) {
+      // ensure scrollEventListener is added/removed when scrollbar config is changed
+      this.ngOnDestroy();
+      this.ngOnInit();
     }
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The ScrollerComponent currently only adds the `scroll` event listener on init, but if the scrollH/scrollV is dynamically updated, then the event listener is never added. This then leads to horizontal scroll not scrolling the column headers in sync with the columns.

**What is the new behavior?**
Add ngOnChanges hook remove/add the `scroll` event listener as needed (just reuses ngOnDestroy and ngOnInit in sequence).

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Intermediate work-around:
```typescript
// Run when scrollH/scrollV inputs to ngxDatatable change (may have to delay to allow it to propagate to the scroller first)
// Fix ngxDataTable only setting up scrolling on initial load (not on change)
const scroller = this.ngxDatatable.bodyComponent.scroller;
this.ngxDatatable.bodyComponent.scroller.ngOnDestroy();
this.ngxDatatable.bodyComponent.scroller.ngOnInit;
```