### PR TITLE
perf/fix: Ivy compatibility changes for performance and correctness

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
@@ -556,17 +556,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    * if described in your markup.
    */
   @ContentChildren(DataTableColumnDirective)
-  set columnTemplates(val: QueryList<DataTableColumnDirective>) {
-    this._columnTemplates = val;
-    this.translateColumns(val);
-  }
-
-  /**
-   * Returns the column templates.
-   */
-  get columnTemplates(): QueryList<DataTableColumnDirective> {
-    return this._columnTemplates;
-  }
+  columnTemplates: QueryList<DataTableColumnDirective>;
 
   /**
    * Row Detail templates gathered from the ContentChild
@@ -702,6 +692,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    */
   ngAfterContentInit() {
     this.columnTemplates.changes.subscribe(v => this.translateColumns(v));
+    this.translateColumns(this.columnTemplates);
     this.listenForColumnInputChanges();
   }
 


### PR DESCRIPTION
Ivy compatibility: Queries instead subscribe to `changes`, not use a setter

The Ivy runtime _always_ calls the setter for the queries:
https://github.com/angular/angular/blob/fe691935091aaf7090864c8111a15f7cc7e53b6c/packages/compiler/src/render3/view/compiler.ts#L446-L452
Resulting in generated code like the following:
`i0.ɵɵqueryRefresh(_t = i0.ɵɵloadQuery()) && (ctx.columnTemplates = _t);`

This generally sets the property to the same query instance. The documented way
to react to changes in the query value is to subscribe to the `changes`, not use
a setter on the property with the query attribute.

By having the setter here, this effectively causes constant refreshes because
the `translateColumns` function recalculates columns, rows, and marks the
component dirty again.

In addition, by recalculating rows and columns, this causes the input
setter for `DataTableBodyComponent` to run again, which clears row
expansions, effectively making it impossible to have a row expansion
stick.
