### PR TITLE
Fix: broken link to demo source code

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -44,5 +44,5 @@ export class AppComponent {
 and you're off to the races!
 
 For more examples, visit the
-[demos](https://github.com/swimlane/angular2-data-table/tree/master/demo) directory
+[demos](https://github.com/swimlane/ngx-datatable/tree/master/src/app) directory
 in the source code!


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The getting started docs link to a "Demo's" directory that is no longer active (404)

**What is the new behavior?**
Updated the link on the page to go to the new source code page: https://github.com/swimlane/ngx-datatable/tree/master/src/app

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
