### PR TITLE
Removing inline editing from manifesto

### DIFF
--- a/docs/introduction/architecture.md
+++ b/docs/introduction/architecture.md
@@ -19,7 +19,6 @@ Some examples of the things we don't plan to build in this project are:
 - Context Menus
 - Column Filters
 - Column Toggling
-- Inline Editing
 
 If you are interested in building something like that for this project, I'm happy
 to help point you in the right direction and would be happy to list a link as a


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe: Update Manifesto

**What is the current behavior?** (You can also link to an open issue here)
In the manifesto section there is a line saying that the "inline editor" is one feature that will not be implemented but if you check the live samples there is one sample about inline editor

**What is the new behavior?**
The "inline editor" is not shown in the manifesto

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Current manifesto
![image](https://user-images.githubusercontent.com/14807967/148608881-820571ff-b70b-4b74-8064-52e262c1baf4.png)

Current live examples
![image](https://user-images.githubusercontent.com/14807967/148609312-bd0d57ac-b39f-4afc-8847-0a2e749d9524.png)



