### PR TITLE
Add all components/directives to module exports

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/ngx-datatable.module.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/ngx-datatable.module.ts
@@ -66,18 +66,34 @@ import { DataTableSummaryRowComponent } from './components/body/summary/summary-
     DataTableSummaryRowComponent
   ],
   exports: [
+    DataTableFooterTemplateDirective,
+    VisibilityDirective,
+    DraggableDirective,
+    ResizeableDirective,
+    OrderableDirective,
+    LongPressDirective,
+    ScrollerComponent,
     DatatableComponent,
+    DataTableColumnDirective,
+    DataTableHeaderComponent,
+    DataTableHeaderCellComponent,
+    DataTableBodyComponent,
+    DataTableFooterComponent,
+    DataTablePagerComponent,
+    ProgressBarComponent,
+    DataTableBodyRowComponent,
+    DataTableRowWrapperComponent,
     DatatableRowDetailDirective,
     DatatableGroupHeaderDirective,
     DatatableRowDetailTemplateDirective,
-    DataTableColumnDirective,
+    DataTableBodyCellComponent,
+    DataTableSelectionComponent,
     DataTableColumnHeaderDirective,
     DataTableColumnCellDirective,
     DataTableColumnCellTreeToggle,
-    DataTableFooterTemplateDirective,
     DatatableFooterDirective,
-    DataTablePagerComponent,
-    DatatableGroupHeaderTemplateDirective
+    DatatableGroupHeaderTemplateDirective,
+    DataTableSummaryRowComponent
   ]
 })
 export class NgxDatatableModule {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe: See under "Other information"

**What is the current behavior?** (You can also link to an open issue here)
All components and directives are not exported

**What is the new behavior?**
All components and directives are exported

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No

**Other information**:

Functionally this makes no difference for consumers of the library. However, we are building some features on top of this table that are very specific to our usecase. In other words, getting our changes into this project is not feasible. We're unable to build our features on top of this table without cloning the repo into our own code. Obviously this is not a good solution in the long-term. By exporting the components, we're able to reuse everything from this library and only override the ones we need. Without exporting them the components are unknown to angular. 