### PR TITLE
Allow Dev's to customise cell tooltips/title

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -290,24 +290,32 @@ export class DataTableBodyCellComponent implements DoCheck, OnDestroy {
 
   checkValueUpdates(): void {
     let value = '';
+    let sanitizedValue = '';
 
     if (!this.row || !this.column) {
       value = '';
     } else {
       const val = this.column.$$valueGetter(this.row, this.column.prop);
       const userPipe: PipeTransform = this.column.pipe;
+      const titlePipe: PipeTransform = this.column.titlePipe;
 
       if (userPipe) {
         value = userPipe.transform(val);
       } else if (value !== undefined) {
         value = val;
       }
+
+      if (titlePipe) {
+        sanitizedValue = titlePipe.transform(val);
+      } else {
+        sanitizedValue = value !== null && value !== undefined ? this.stripHtml(value) : value;
+      }
     }
 
     if (this.value !== value) {
       this.value = value;
       this.cellContext.value = value;
-      this.sanitizedValue = value !== null && value !== undefined ? this.stripHtml(value) : value;
+      this.sanitizedValue = sanitizedValue;
       this.cd.markForCheck();
     }
   }

--- a/projects/swimlane/ngx-datatable/src/lib/components/columns/column.directive.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/columns/column.directive.ts
@@ -15,6 +15,7 @@ export class DataTableColumnDirective implements OnChanges {
   @Input() resizeable: boolean;
   @Input() comparator: any;
   @Input() pipe: any;
+  @Input() titlePipe: any;
   @Input() sortable: boolean;
   @Input() draggable: boolean;
   @Input() canAutoResize: boolean;

--- a/projects/swimlane/ngx-datatable/src/lib/types/table-column.type.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/types/table-column.type.ts
@@ -107,6 +107,13 @@ export interface TableColumn {
   pipe?: PipeTransform;
 
   /**
+   * Custom title pipe transforms
+   *
+   * @memberOf TableColumn
+   */
+  titlePipe?: PipeTransform;
+
+  /**
    * Can the column be sorted
    *
    * @memberOf TableColumn

--- a/src/app/basic/basic-auto.component.ts
+++ b/src/app/basic/basic-auto.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { ColumnMode } from 'projects/swimlane/ngx-datatable/src/public-api';
+import { GenderPipe } from '../pipes/gender.pipe';
 
 @Component({
   selector: 'basic-auto-demo',
@@ -36,7 +37,7 @@ export class BasicAutoComponent {
   loadingIndicator = true;
   reorderable = true;
 
-  columns = [{ prop: 'name' }, { name: 'Gender' }, { name: 'Company', sortable: false }];
+  columns = [{ prop: 'name' }, { name: 'Gender', titlePipe: new GenderPipe() }, { name: 'Company', sortable: false }];
 
   ColumnMode = ColumnMode;
 

--- a/src/app/basic/basic-fixed.component.ts
+++ b/src/app/basic/basic-fixed.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { ColumnMode } from 'projects/swimlane/ngx-datatable/src/public-api';
+import { GenderPipe } from '../pipes/gender.pipe';
 
 @Component({
   selector: 'basic-fixed-demo',
@@ -31,7 +32,7 @@ import { ColumnMode } from 'projects/swimlane/ngx-datatable/src/public-api';
 })
 export class BasicFixedComponent {
   rows = [];
-  columns = [{ prop: 'name' }, { name: 'Company' }, { name: 'Gender' }];
+  columns = [{ prop: 'name' }, { name: 'Company' }, { name: 'Gender', titlePipe: new GenderPipe() }];
 
   ColumnMode = ColumnMode;
 

--- a/src/app/basic/css.component.ts
+++ b/src/app/basic/css.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { ColumnMode } from 'projects/swimlane/ngx-datatable/src/public-api';
+import { GenderPipe } from '../pipes/gender.pipe';
 
 @Component({
   selector: 'row-css-demo',
@@ -26,7 +27,12 @@ import { ColumnMode } from 'projects/swimlane/ngx-datatable/src/public-api';
         [scrollbarV]="true"
       >
         <ngx-datatable-column name="Name"></ngx-datatable-column>
-        <ngx-datatable-column name="Gender" headerClass="is-gender" [cellClass]="getCellClass"></ngx-datatable-column>
+        <ngx-datatable-column
+          name="Gender"
+          [titlePipe]="genderPipe"
+          headerClass="is-gender"
+          [cellClass]="getCellClass"
+        ></ngx-datatable-column>
         <ngx-datatable-column name="Age"></ngx-datatable-column>
       </ngx-datatable>
     </div>
@@ -36,6 +42,7 @@ export class RowCssComponent {
   rows = [];
   expanded = {};
   timeout: any;
+  genderPipe = new GenderPipe();
 
   ColumnMode = ColumnMode;
 

--- a/src/app/pipes/gender.pipe.ts
+++ b/src/app/pipes/gender.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'gender' })
+export class GenderPipe implements PipeTransform {
+  transform(value: string): string {
+    if (!value || value === '') {
+      return '';
+    } else {
+      switch (value) {
+        case 'female':
+          return `${value} ♀`;
+        case 'male':
+          return `${value} ♂`;
+        default:
+          return value;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Using similar pipe transform for cell contents, allow devs to customise data in tooltips based on specifying pipe transform in column declaration.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** 
Unable to customise cell tooltips/titles

**What is the new behavior?**
Able to use pipetransform to change cell tooltip/titles

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
