### PR TITLE
Add the tree level as css class to each row

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -106,6 +106,8 @@ export class DataTableBodyRowComponent implements DoCheck {
       cls += ' datatable-row-even';
     }
 
+    cls += ' datatable-row-level-' + (this.row?.level ?? 0);
+
     if (this.rowClass) {
       const res = this.rowClass(this.row);
       if (typeof res === 'string') {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**
Added `datatable-row-level-i` to the classes of the body row, with `i` representing the level in the tree structure, to allow for further css styling.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
