### PR TITLE
update summarytemplate type

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/types/table-column.type.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/types/table-column.type.ts
@@ -1,4 +1,4 @@
-import { PipeTransform } from '@angular/core';
+import { PipeTransform, TemplateRef } from '@angular/core';
 import { ValueGetter } from '../utils/column-prop-getters';
 
 /**
@@ -215,5 +215,5 @@ export interface TableColumn {
    *
    * @memberOf TableColumn
    */
-  summaryTemplate?: any;
+  summaryTemplate?: TemplateRef<any>;
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Updating type

**What is the current behavior?** (You can also link to an open issue here)
We can pass anything into `summaryTemplate` since it isn't strongly typed

**What is the new behavior?**
We restrict it to `TemplateRef<any>`

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: 
If anything other than `TemplateRef` or `undefined` gets passed in, it'll show up as a type error and that should be updated.

**Other information**:
This is based off [summary-row.component.ts](https://github.com/swimlane/ngx-datatable/blob/master/projects/swimlane/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts#L3), we can also pick it off `ISummaryColumn` and move doco over.
```ts
interface TableColumn extends Pick<ISummaryColumn, 'summaryFunc' | 'summaryTemplate'
```