### PR TITLE
Adapt RxJS peer dependency version to allow clients to use v6 or v7 at will with Angular 13

### DIFF
--- a/projects/swimlane/ngx-datatable/package.json
+++ b/projects/swimlane/ngx-datatable/package.json
@@ -6,7 +6,7 @@
     "@angular/common": ">=11.0.2",
     "@angular/core": ">=11.0.2",
     "@angular/platform-browser": ">=11.0.2",
-    "rxjs": "^6.6.3"
+    "rxjs": "^6.6.3 || ^7.4.0"
   },
   "dependencies": {
     "tslib": "^2.0.0"

--- a/projects/swimlane/ngx-datatable/src/lib/services/column-changes.service.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/services/column-changes.service.ts
@@ -8,9 +8,9 @@ import { Observable, Subject } from 'rxjs';
  */
 @Injectable()
 export class ColumnChangesService {
-  private columnInputChanges = new Subject<undefined>();
+  private columnInputChanges = new Subject<void>();
 
-  get columnInputChanges$(): Observable<undefined> {
+  get columnInputChanges$(): Observable<void> {
     return this.columnInputChanges.asObservable();
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?
Users switching to Angular 13+ and RxJS v7 cannot install this library because of version conflicts: Ngx-Datatable uses RxJS v6.
Basically all mentioned here: #2087, #2080, #2073, #2042

**What is the new behavior?**
Loosen the peer dependency for RxJS so that clients can decide which version to use: v6 or v7. The [RxJS breaking-changes from v7](https://rxjs.dev/deprecations/breaking-changes) don't affect Ngx-Datatable. Only a couple of lines needed to be fixed, but technically not related to the new RxJS version but to better type checks . You can try it out by changing directly the version to use in the `package.json`.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
I didn't include the `package-lock.json`file cause I have another version of NPM, so I prefer you have a look on this and re-generate it. I've tested these changes with the 2 versions of RxJS separately: v6 and v7
