### PR TITLE
Allow 'auto' to be passed as a height

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
@@ -189,13 +189,13 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
    * The minimum header height in pixels.
    * Pass a falsey for no header
    */
-  @Input() headerHeight: number = 30;
+  @Input() headerHeight: number | 'auto' = 30;
 
   /**
    * The minimum footer height in pixels.
    * Pass falsey for no footer
    */
-  @Input() footerHeight: number = 0;
+  @Input() footerHeight: number | 'auto' = 0;
 
   /**
    * If the table should use external paging
@@ -851,8 +851,8 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
 
     if (this.scrollbarV) {
       let height = dims.height;
-      if (this.headerHeight) height = height - this.headerHeight;
-      if (this.footerHeight) height = height - this.footerHeight;
+      if (this.headerHeight) height = height - (this.headerHeight as number);
+      if (this.footerHeight) height = height - (this.footerHeight as number);
       this.bodyHeight = height;
     }
 

--- a/projects/swimlane/ngx-datatable/src/lib/components/footer/footer.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/footer/footer.component.ts
@@ -45,7 +45,7 @@ import { DatatableFooterDirective } from './footer.directive';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DataTableFooterComponent {
-  @Input() footerHeight: number;
+  @Input() footerHeight: number | 'auto';
   @Input() rowCount: number;
   @Input() pageSize: number;
   @Input() offset: number;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The [headerHeight](https://swimlane.gitbook.io/ngx-datatable/api/table/inputs#headerheight) and [footerHeight](https://swimlane.gitbook.io/ngx-datatable/api/table/inputs#headerheight) inputs of `ngx-datatable` accept the 'auto' value as well as numbers, going as far as [verifying if their values match that specific string](https://github.com/swimlane/ngx-datatable/blob/master/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts#L467). However, their current type signature allows for numbers only. This type conflict pops up when using `strictTemplates` as an [Angular Compiler Option](https://angular.io/guide/angular-compiler-options#stricttemplates).

**What is the new behavior?**
The two aforementioned inputs will now allow the 'auto' value to be passed without incurring in build errors when template type checking is enabled.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No
