### PR TITLE
Fix memory leaks

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
@@ -122,6 +122,7 @@ import { translateXY } from '../../utils/translate';
   }
 })
 export class DataTableBodyComponent implements OnInit, OnDestroy {
+  static _timeOutID: any;
   @Input() scrollbarV: boolean;
   @Input() scrollbarH: boolean;
   @Input() loadingIndicator: boolean;
@@ -327,6 +328,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     if (this.rowDetail || this.groupHeader) {
       this.listener.unsubscribe();
     }
+    clearTimeout(DataTableBodyComponent._timeOutID);
   }
 
   /**
@@ -576,7 +578,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    * Hides the loading indicator
    */
   hideIndicator(): void {
-    setTimeout(() => (this.loadingIndicator = false), 500);
+    DataTableBodyComponent._timeOutID = setTimeout(() => (this.loadingIndicator = false), 500);
   }
 
   /**

--- a/projects/swimlane/ngx-datatable/src/lib/components/body/scroller.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/scroller.component.ts
@@ -23,6 +23,7 @@ import { MouseEvent } from '../../events';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ScrollerComponent implements OnInit, OnDestroy {
+  static _requestID: any;
   @Input() scrollbarV: boolean = false;
   @Input() scrollbarH: boolean = false;
 
@@ -65,6 +66,7 @@ export class ScrollerComponent implements OnInit, OnDestroy {
       this.parentElement.removeEventListener('scroll', this._scrollEventListener);
       this._scrollEventListener = null;
     }
+    cancelAnimationFrame(ScrollerComponent._requestID);
   }
 
   setOffset(offsetY: number): void {
@@ -75,7 +77,7 @@ export class ScrollerComponent implements OnInit, OnDestroy {
 
   onScrolled(event: MouseEvent): void {
     const dom: Element = <Element>event.currentTarget;
-    requestAnimationFrame(() => {
+    ScrollerComponent._requestID = requestAnimationFrame(() => {
       this.scrollYPos = dom.scrollTop;
       this.scrollXPos = dom.scrollLeft;
       this.updateOffset();

--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
@@ -57,6 +57,7 @@ import { sortRows } from '../utils/sort';
   }
 })
 export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
+  static _requestID: any;
   /**
    * Template for the target marker of drag target columns.
    */
@@ -681,7 +682,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
       return;
     }
 
-    requestAnimationFrame(() => {
+    DatatableComponent._requestID = requestAnimationFrame(() => {
       this.recalculate();
 
       // emit page for virtual server-side kickoff
@@ -1135,6 +1136,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
 
   ngOnDestroy() {
     this._subscriptions.forEach(subscription => subscription.unsubscribe());
+    cancelAnimationFrame(DatatableComponent._requestID);
   }
 
   /**

--- a/projects/swimlane/ngx-datatable/src/lib/directives/orderable.directive.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/directives/orderable.directive.ts
@@ -40,6 +40,7 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
       d.dragging.unsubscribe();
       d.dragEnd.unsubscribe();
     });
+    this.draggables?.destroy();
   }
 
   updateSubscriptions(): void {

--- a/src/app/basic/live.component.ts
+++ b/src/app/basic/live.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, ViewChild, ChangeDetectorRef, OnDestroy, HostListener } from '@angular/core';
 import { ColumnMode } from 'projects/swimlane/ngx-datatable/src/public-api';
 
 @Component({
@@ -40,7 +40,8 @@ import { ColumnMode } from 'projects/swimlane/ngx-datatable/src/public-api';
     </div>
   `
 })
-export class LiveDataComponent {
+export class LiveDataComponent implements OnDestroy {
+  static _timeOutID: any;
   @ViewChild('mydatatable') mydatatable: any;
 
   count = 50;
@@ -73,7 +74,7 @@ export class LiveDataComponent {
       return;
     }
 
-    setTimeout(this.updateRandom.bind(this), 50);
+    LiveDataComponent._timeOutID = setTimeout(this.updateRandom.bind(this), 50);
   }
 
   stop(): void {
@@ -117,5 +118,10 @@ export class LiveDataComponent {
     };
 
     req.send();
+  }
+
+  @HostListener('unloaded')
+  public ngOnDestroy(): void {
+    clearTimeout(LiveDataComponent._timeOutID);
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**
Significant memory leakage

**What is the new behavior?**
Significant reduction in memory leakage

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
-----------------------------------
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications and their libraries. While running the tool and analyzing the code of ngx-datatable, we saw that your project does a very good job of ensuring that all async operations are cancelled when components destroy. However, as per Memlab execution results, we found some dangling animation frame requests, timeout calls and QueryLists, that were causing the memory to leak (screenshots below).


[before]
<img width="959" alt="Screen Shot 2023-02-03 at 7 49 08 AM" src="https://user-images.githubusercontent.com/56495631/216476452-33105ccd-6154-4a32-9a52-920de5df481b.png">

<img width="692" alt="Screen Shot 2023-02-03 at 8 32 11 AM" src="https://user-images.githubusercontent.com/56495631/216476324-1cb49aab-4036-4319-a62b-82d4bda4e109.png">

Hence we added the fix by clearing the frame requests, timeout calls and querylists in destructor, and you can see the heap size and # of leaks reducing noticeably:
 <br />
<img width="1009" alt="Screen Shot 2023-02-03 at 6 11 11 AM" src="https://user-images.githubusercontent.com/56495631/216476606-4ea2baf4-ccc8-41d1-b7ad-39f9df3eb3c0.png">


Note 1. Host listener is used to ensure that ngOnDestroy is called not only when the class destroy, but also when the page refreshes, tab or browser closes or the user navigates away from the page[1]

Note 2. Static property is used to avoid losing the context of the correct ‘this’ in case any nesting changes are made to the enclosing function in future.

We executed the test suite before and after the changes, where it executed 126 of 129 (skipped 3, TOTAL: 126 SUCCESS) in both cases.

You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering the maximum # of use cases.

Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in .txt form):
[ngx-database-scenario-memlab.txt](https://github.com/swimlane/ngx-datatable/files/10574350/ngx-database-scenario-memlab.txt)

Note that some other reported leaks (in Memlab) originated from Angular's internal objects, hence were ignored.

Reference.
[1] https://wesleygrimes.com/angular/2019/03/29/making-upgrades-to-angular-ngondestroy.html




