### PR TITLE
refactor(footer): removed irrelevant inputs

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/footer/footer.directive.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/footer/footer.directive.ts
@@ -3,14 +3,6 @@ import { DataTableFooterTemplateDirective } from './footer-template.directive';
 
 @Directive({ selector: 'ngx-datatable-footer' })
 export class DatatableFooterDirective {
-  @Input() footerHeight: number;
-  @Input() totalMessage: string;
-  @Input() selectedMessage: string | boolean;
-  @Input() pagerLeftArrowIcon: string;
-  @Input() pagerRightArrowIcon: string;
-  @Input() pagerPreviousIcon: string;
-  @Input() pagerNextIcon: string;
-
   @Input('template')
   _templateInput: TemplateRef<any>;
 


### PR DESCRIPTION
Removed @Inputs which are not relevant and has no effect at all.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

certain @Inputs  in `<ngx-datatable-footer>` for custom footer has no meaning doesn't do anything.

**What is the new behavior?**
Removed such @Inputs which are not relevant.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
