### PR TITLE
Fix: Addition of safe code when accessing this._rowDiffer

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -160,7 +160,7 @@ export class DataTableBodyRowComponent implements DoCheck {
   }
 
   ngDoCheck(): void {
-    if (this._rowDiffer.diff(this.row)) {
+    if (this._rowDiffer && this._rowDiffer.diff(this.row)) {
       this.cd.markForCheck();
     }
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)**
A Kibana error logged on behalf of our saas platform with the error: `this._rowDiffer is undefined`. 


**What is the new behavior?**
Added some safe code to prevent this error.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
n/a

**Other information**:

**Addition info from Kibana log**

```
{
  "_index": "admin-v2-2023.10.30",
  "_type": "doc",
  "_id": "LMNMgosBRe6EzFrlioq2",
  "_version": 1,
  "_score": null,
  "_source": {
    "timestamp": "Oct 30 20:35:33",
    "severity_label": "Error",
    "type": "php_messages",
    "data_center": "whk1",
    "program": "ADMIN-V2",
    "@timestamp": "2023-10-30T20:35:33.000Z",
    "priority": 155,
    "data": {
      "errorType": "generic",
      "user": "wiflix_net",
      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/119.0",
      "name": "TypeError",
      "stack": {
        "lineNumber": 1,
        "fileName": "https://admin.adnation.com/main.d1e04289377265dd.js",
        "functionName": "value",
        "source": "value@https://admin.adnation.com/main.d1e04289377265dd.js:1:4989379",
        "columnNumber": 4989379
      },
      "body": null,
      "detailErrMsg": null,
      "status": null,
      "id": "ADMIN-V2-1698698131715",
      "appId": "ADMIN-V2",
      "errMsg": "this._rowDiffer is undefined",
      "appVersion": "3.439.3",
      "payload": "",
      "time": 1698698131715
    },
    "severity": 3,
    "facility_label": "local3",
    "facility": 19,
    "host": "127.0.0.1",
    "logstash_processed": "true",
    "pid": "5033",
    "logsource": "exo-whk1-sweb1.isprime.com",
    "@version": "1"
  },
  "fields": {
    "@timestamp": [
      "2023-10-30T20:35:33.000Z"
    ]
  },
  "highlight": {
    "logsource.keyword": [
      "@kibana-highlighted-field@exo-whk1-sweb1.isprime.com@/kibana-highlighted-field@"
    ]
  },
  "sort": [
    1698698133000
  ]
}
```