### PR TITLE
(release): 21.1.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 21.1.0
+
 - Fix: Prevent browser page crash when user inputs large Arrays
 
 ## 21.0.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ It has all the features you would expect from any other table but in a light pac
 with _no external dependencies_. The table was designed to be extremely flexible and light;
 it doesn't make any assumptions about your data or how you: filter, sort or page it.
 
-It was built for modern browsers using _TypeScript, CSS3 and HTML5_ and Angular `>=4.0.0`.
+It was originally built for modern browsers using _TypeScript, CSS3 and HTML5_ and Angular `>=4.0.0`.
 This is the sister project of the [angular-data-table](https://github.com/swimlane/angular-data-table)
 that is designed for Angular 1.x.
 
@@ -17,3 +17,32 @@ that is designed for Angular 1.x.
 
 The project was featured on [AngularAir](https://angularair.com/) where [@amcdnl](https://github.com/amcdnl)
 spoke about the project, challenges and whats to come.
+
+## Development server
+
+Run `yarn start` to serve the demo at `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+
+## Building
+
+Run `yarn build` to build the project. The build artifacts will be stored in the `dist/` directory.
+
+## Running tests
+
+- Run `yarn test` to execute the linter, prettier check, unit and end-to-end tests.
+
+## Release
+
+- Checkout master (`git checkout master`)
+- Pull master (`git pull`)
+- Refresh node modules (`yarn install --frozen-lockfile`)
+- Run tests (`yarn test`)
+- Examine log to determine next version (X.Y.Z)
+- Run `git checkout -b release/X.Y.Z`
+- Update version in `projects/swimlane/ngx-datatable/package.json`.
+- Update changelog in `docs/CHANGELOG.md`
+- Run `yarn package` to build the package
+- Run `git commit -am "(release): X.Y.Z"`
+- Run `git tag X.Y.Z`
+- Run `git push origin HEAD --tags`
+- Run `yarn publish`
+- Submit PR

--- a/projects/swimlane/ngx-datatable/package.json
+++ b/projects/swimlane/ngx-datatable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-datatable",
-  "version": "21.0.0",
+  "version": "21.1.0",
   "description": "ngx-datatable is an Angular table grid component for presenting large and complex data.",
   "peerDependencies": {
     "@angular/common": "17.x || 18.x || 19.x",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- Fix: Prevent browser page crash when user inputs large Arrays

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`InterableDiffer` internally checks if there is a difference between rows during change detection. This method can cause a page crash issue when many rows are input into the table, possibly more than ngx-datatable can handle. Reverting to the previous method `KeyValueDiffer` fixes the issue and retains the same functionality.

**What is the new behavior?**

`KeyValueDiffer` fixes the issue and retains the same functionality. This method was used in prior major versions.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
