### PR TITLE
refactor: move DOCUMENT import from @angular/core to @angular/common

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/directives/orderable.directive.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/directives/orderable.directive.ts
@@ -2,7 +2,6 @@ import {
   AfterContentInit,
   ContentChildren,
   Directive,
-  DOCUMENT,
   EventEmitter,
   inject,
   KeyValueChangeRecord,
@@ -12,6 +11,7 @@ import {
   Output,
   QueryList
 } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { DraggableDirective } from './draggable.directive';
 
 import {

--- a/projects/swimlane/ngx-datatable/src/lib/services/scrollbar-helper.service.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/services/scrollbar-helper.service.ts
@@ -1,4 +1,5 @@
-import { DOCUMENT, inject, Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 
 /**
  * Gets the width of the scrollbar.  Nesc for windows


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

In an Angular application version 19.
* Swimlane/ngx-datatable version 22.0.0 is installed.
* The NgxDatatableModule is configured.
* The application is served.
* The error is visible. 

```
 X [ERROR] No matching export in "node_modules/.pnpm/@angular+core@19.2.15_rxjs@7.8.2_zone.js@0.15.1/node_modules/@angular/core/fesm2022/core.mjs" for import "DOCUMENT"

node_modules/.pnpm/@swimlane+ngx-datatable@22._0e939b4033fa2a9aedc7471838ba02ad/node_modules/@swimlane/ngx-datatable/fesm2022/swimlane-ngx-datatable.mjs:2:343:
      2 │ ... signal, IterableDiffers, ViewChild, computed, DOCUMENT, ContentChildren, NgZone, input, effect, Ng...
```
This happens if you use npm or pnpm to install dependencies or serve the application.

https://github.com/swimlane/ngx-datatable/issues/2253


**What is the new behavior?**

DOCUMENT is now imported from @angular/cli

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Official documentation about DOCUMENT 
https://angular.dev/api/common/DOCUMENT



