### PR TITLE
(release): 23.0.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 23.0.1
+
 - Fix: Fixing scroller Issue in datatable when multiple columns are there in datatable
 
 ## 22.0.0

--- a/projects/swimlane/ngx-datatable/package.json
+++ b/projects/swimlane/ngx-datatable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-datatable",
-  "version": "22.0.0",
+  "version": "23.0.1",
   "description": "ngx-datatable is an Angular table grid component for presenting large and complex data.",
   "peerDependencies": {
     "@angular/common": "18.x || 19.x || 20.x",


### PR DESCRIPTION
Ships bugfix for datatable scroller with multiple columns as 23.0.1 (semver patch after 23.0.0; lower numbers like 22.1.0 / 22.2.0 are already taken on the remote).
CHANGELOG only covers this release; there are no retroactive entries for versions we did not publish from this branch.

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: updates package version and changelog entry with no runtime/code changes.
> 
> **Overview**
> Cuts a `23.0.1` patch release by bumping `@swimlane/ngx-datatable` from `22.0.0` to `23.0.1` and adding a corresponding changelog entry for the datatable scroller fix when multiple columns are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8dc1f8d76366059df75128698a9ca916c00cdea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->