### PR TITLE
(release): 24.0.0-alpha.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 24.0.0-alpha.0
+
 - Enhancement: Added support for Angular 21
 - Breaking: Removed support for Angular 18 and earlier versions
 

--- a/projects/ngx-datatable/package.json
+++ b/projects/ngx-datatable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-datatable",
-  "version": "25.0.0",
+  "version": "24.0.0-alpha.0",
   "description": "ngx-datatable is an Angular table grid component for presenting large and complex data.",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Support for angular 21 and vitest
**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [X] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
Removing anguilar 18 support
**Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this is release metadata only (changelog + package version), with no runtime code changes. Main risk is publishing/consuming the wrong version tag if release automation expects a different semver progression.
> 
> **Overview**
> Bumps `@swimlane/ngx-datatable` to the `24.0.0-alpha.0` prerelease version.
> 
> Updates `docs/CHANGELOG.md` to add the `24.0.0-alpha.0` entry, documenting **Angular 21 support** and a **breaking drop of Angular 18 and earlier**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40965c3ea3d94180f7a3bca8bc55b8671a3b5717. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->