### PR TITLE
Fix scroller minWidth regression after Angular 21 refactor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix: Fixing scroller Issue in datatable when multiple columns are there in datatable
+
 ## 24.0.0-alpha.0
 
 - Enhancement: Added support for Angular 21

--- a/projects/swimlane/ngx-datatable/src/lib/components/body/scroller.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/scroller.component.ts
@@ -26,7 +26,7 @@ export interface ScrollEventInternal {
   host: {
     'class': 'datatable-scroll',
     '[style.height.px]': 'scrollHeight()',
-    '[style.width.px]': 'scrollWidth()'
+    '[style.minWidth.px]': 'scrollWidth()'
   }
 })
 export class ScrollerComponent implements OnInit, OnDestroy {


### PR DESCRIPTION
DOD - 

<img width="884" height="733" alt="image" src="https://github.com/user-attachments/assets/43b1ca04-3504-4b76-b6ed-bfc5aab438a2" />


Restore minWidth binding on datatable-scroller that was accidentally changed to width during the signals migration, fixing horizontal scrolling when the table has multiple columns.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** scroller has scrollWidth as width

**What is the new behavior?** scroller will have scrollWidth as minwidth

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS binding change on the scroller host with no API or auth/data impact; low regression risk aside from layout/scroll behavior.
> 
> **Overview**
> Fixes a **regression in `datatable-scroller`** where the host binding used **`width`** instead of **`minWidth`** for `scrollWidth()` (introduced during the Angular 21 signals migration).
> 
> Restoring **`minWidth`** lets the scroll area grow with total column width so **horizontal scrolling works again** when the table has multiple columns. Documents the fix under **HEAD (unreleased)** in the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d22e1954ac72bd98f6201a89d3fc98f57d81d51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->