### PR TITLE
Release/24.0.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## HEAD (unreleased)
 
+## 24.0.0
+
+- Enhancement: Added support for Angular 21
+- Breaking: Removed support for Angular 18 and earlier versions
+
 ## 24.0.0-alpha.0
 
 - Enhancement: Added support for Angular 21

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@angular/compiler-cli": "21.2.9",
     "@angular/language-service": "21.2.9",
     "@swimlane/eslint-config": "^2.0.0",
-    "@swimlane/prettier-config-swimlane": "4.0.0-alpha.0",
+    "@swimlane/prettier-config-swimlane": "4.0.0",
     "@types/node": "^24.0.0",
     "@typescript-eslint/eslint-plugin": "8.23.0",
     "@typescript-eslint/parser": "8.23.0",

--- a/projects/ngx-datatable/package.json
+++ b/projects/ngx-datatable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-datatable",
-  "version": "24.0.0-alpha.0",
+  "version": "24.0.0",
   "description": "ngx-datatable is an Angular table grid component for presenting large and complex data.",
   "publishConfig": {
     "access": "public"

--- a/projects/swimlane/ngx-datatable/package.json
+++ b/projects/swimlane/ngx-datatable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-datatable",
-  "version": "23.0.1",
+  "version": "24.0.0",
   "description": "ngx-datatable is an Angular table grid component for presenting large and complex data.",
   "peerDependencies": {
     "@angular/common": "19.x || 20.x || 21.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5059,12 +5059,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swimlane/prettier-config-swimlane@npm:4.0.0-alpha.0":
-  version: 4.0.0-alpha.0
-  resolution: "@swimlane/prettier-config-swimlane@npm:4.0.0-alpha.0"
+"@swimlane/prettier-config-swimlane@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@swimlane/prettier-config-swimlane@npm:4.0.0"
   peerDependencies:
     prettier: 3.3.3
-  checksum: 10c0/f552c95628010d6f1aaa8dbd094136b22fe1f643085c8e5b7b64443c741fb5287cecdcb426f0d7c47db57a7b562d4c698357532fb45c6b402b91088050a86f3d
+  checksum: 10c0/e0a99fd4f71e1c4bc6cf9e3e5aa9ad0c82004f1b2e0ff3eeabf64b380faf230fb47db8c7858c09b50c3d90741b8e289ab92a7b97234115e468243b565bc5ab41
   languageName: node
   linkType: hard
 
@@ -14011,7 +14011,7 @@ __metadata:
     "@angular/platform-browser-dynamic": "npm:21.2.9"
     "@angular/router": "npm:21.2.9"
     "@swimlane/eslint-config": "npm:^2.0.0"
-    "@swimlane/prettier-config-swimlane": "npm:4.0.0-alpha.0"
+    "@swimlane/prettier-config-swimlane": "npm:4.0.0"
     "@types/node": "npm:^24.0.0"
     "@typescript-eslint/eslint-plugin": "npm:8.23.0"
     "@typescript-eslint/parser": "npm:8.23.0"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only manifest, changelog, and lockfile changes with no application or library source modifications in the diff.
> 
> **Overview**
> **Promotes the 24.0.0 release** from alpha to stable by bumping `@swimlane/ngx-datatable` to **24.0.0** in the publishable package manifests (`projects/ngx-datatable` from `24.0.0-alpha.0`, `projects/swimlane/ngx-datatable` from `23.0.1`).
> 
> Adds a **24.0.0** section to `docs/CHANGELOG.md` documenting Angular 21 support and the breaking drop of Angular 18 and earlier—the same notes already listed under `24.0.0-alpha.0`.
> 
> Updates root dev tooling from `@swimlane/prettier-config-swimlane` **4.0.0-alpha.0** to **4.0.0**, with matching `yarn.lock` entries. No library source changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5f36737c37959cef800a667f830aec38dced3af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->