### PR TITLE
fix(demo): make inline-edit autofocus work on repeated activation

### DIFF
--- a/src/app/basic/autofocus.directive.ts
+++ b/src/app/basic/autofocus.directive.ts
@@ -1,0 +1,26 @@
+import { AfterViewInit, Directive, ElementRef, inject } from '@angular/core';
+
+/**
+ * Focuses the host element once it is attached to the DOM.
+ *
+ * The native `autofocus` attribute is only honored once, when the browser
+ * first parses the document — it does nothing when an element is created
+ * dynamically (e.g. inside an `@if`/`*ngIf` block), which is why the
+ * inline-edit demo's input/select never received focus after the first
+ * activation.
+ *
+ * Usage:
+ *
+ * 		<input autofocus ... />
+ *
+ */
+@Directive({
+  selector: '[autofocus]'
+})
+export class AutofocusDirective implements AfterViewInit {
+  private element = inject(ElementRef<HTMLElement>);
+
+  ngAfterViewInit(): void {
+    this.element.nativeElement.focus();
+  }
+}

--- a/src/app/basic/inline-editing.component.ts
+++ b/src/app/basic/inline-editing.component.ts
@@ -7,10 +7,16 @@ import {
 
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
+import { AutofocusDirective } from './autofocus.directive';
 
 @Component({
   selector: 'inline-editing-demo',
-  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective],
+  imports: [
+    DatatableComponent,
+    DataTableColumnDirective,
+    DataTableColumnCellDirective,
+    AutofocusDirective
+  ],
   changeDetection: ChangeDetectionStrategy.Eager,
   template: `
     <div>
@@ -43,7 +49,12 @@ import { DataService } from '../data.service';
             ngx-datatable-cell-template
           >
             @if (editing[rowIndex + '-name']) {
-              <input type="text" [value]="value" (blur)="updateValue($event, 'name', rowIndex)" />
+              <input
+                type="text"
+                autofocus
+                [value]="value"
+                (blur)="updateValue($event, 'name', rowIndex)"
+              />
             } @else {
               <span title="Double click to edit" (dblclick)="editing[rowIndex + '-name'] = true">
                 {{ value }}
@@ -64,6 +75,7 @@ import { DataService } from '../data.service';
               </span>
             } @else {
               <select
+                autofocus
                 [value]="value"
                 (blur)="editing[rowIndex + '-gender'] = false"
                 (change)="updateValue($event, 'gender', rowIndex)"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**What is the current behavior?**

Fixes #1887. Double-clicking a cell in the inline-edit demo shows the edit input, but the native `autofocus` HTML attribute doesn't actually focus it — you have to click the field again to start typing.

**What is the new behavior?**

The native `autofocus` attribute is only honored once, when the browser first parses the document — it does nothing when an element is created dynamically (here, inside an `@if` block that toggles on double-click). Added a small `AutofocusDirective` that calls `.focus()` in `ngAfterViewInit()`, which re-runs every time Angular (re)creates the host element, and wired it onto the demo's `<input>` and `<select>`. This is the same approach suggested in the issue thread.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Other information**:

Parts of this fix (root-cause analysis and implementation) were produced with the help of Claude Code — credited via the `Co-authored-by` trailer on the commit. I reviewed and understood the change before opening this PR.

Verification: `ng serve` and `ng build --configuration production` both succeed with this change, and `ng lint` shows the exact same error count (64, all pre-existing, unrelated to this file) before and after — confirmed via `git stash -u` comparison. I was not able to do a live browser click-through in this environment (no browser automation available), so the fix is verified by build/lint plus reasoning through Angular's `ngAfterViewInit` lifecycle timing, not an actual manual click test — flagging that honestly in case a maintainer wants to double check the interaction themselves.