### PR TITLE
Siemens sync A: bugfixes and small features

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.spec.ts
@@ -256,4 +256,55 @@ describe('DataTableBodyComponent', () => {
       expect(component.getGroupExpanded(group)).toBe(true);
     });
   });
+
+  describe('selectRow', () => {
+    const rows = [
+      { id: 1, name: 'Ethel' },
+      { id: 2, name: 'Claudine' },
+      { id: 3, name: 'Beryl' },
+      { id: 4, name: 'Wilder' },
+      { id: 5, name: 'Georgina' }
+    ];
+
+    beforeEach(() => {
+      fixture.componentRef.setInput('rows', rows);
+      fixture.componentRef.setInput('rowCount', rows.length);
+      fixture.componentRef.setInput('pageSize', rows.length);
+      fixture.componentRef.setInput('offset', 0);
+      fixture.componentRef.setInput('selectionType', 'multi');
+      fixture.componentRef.setInput('selected', []);
+    });
+
+    it('should keep prior ctrl-selected rows when shift-clicking a range', () => {
+      // Regression for https://github.com/swimlane/ngx-datatable/issues/582
+      // 1. Click Georgina (idx 4)
+      component.selectRow(new MouseEvent('click'), 4, rows[4]);
+      expect(component.selected()).toEqual([rows[4]]);
+
+      // 2. Ctrl-click Beryl (idx 2) - extends selection, becomes new anchor
+      component.selectRow(new MouseEvent('click', { ctrlKey: true }), 2, rows[2]);
+      expect(component.selected()).toEqual([rows[4], rows[2]]);
+
+      // 3. Shift-click Ethel (idx 0) - range from last anchor (Beryl, idx 2) to Ethel (idx 0)
+      component.selectRow(new MouseEvent('click', { shiftKey: true }), 0, rows[0]);
+
+      const selected = component.selected();
+      // Georgina must still be selected (the bug)
+      expect(selected).toContain(rows[4]);
+      // Range Beryl..Ethel must be selected
+      expect(selected).toContain(rows[2]);
+      expect(selected).toContain(rows[1]);
+      expect(selected).toContain(rows[0]);
+      // No duplicates (Beryl was already selected before shift-click)
+      expect(selected.length).toBe(new Set(selected).size);
+    });
+
+    it('should not throw when shift is the very first click', () => {
+      expect(() =>
+        component.selectRow(new MouseEvent('click', { shiftKey: true }), 2, rows[2])
+      ).not.toThrow();
+      // First-ever shift-click without a prior anchor selects just the clicked row.
+      expect(component.selected()).toEqual([rows[2]]);
+    });
+  });
 });

--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
@@ -95,8 +95,8 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
         [scrollbarV]="scrollbarV"
         [scrollbarH]="scrollbarH()"
         [scrollHeight]="scrollHeight()"
-        [scrollWidth]="columnGroupWidths?.total"
-        [class.horizontal-overflow]="innerWidth() < (columnGroupWidths?.total ?? 0)"
+        [scrollWidth]="columnGroupWidths.total"
+        [class.horizontal-overflow]="innerWidth() < columnGroupWidths.total"
         (scroll)="onBodyScroll($event)"
       >
         @if ((summaryRow() || summaryRowTemplate()) && summaryPosition() === 'top') {

--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
@@ -865,8 +865,14 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
 
     // TODO: this code needs cleanup. Casting it to KeyboardEvent is not correct as it could also be other types.
     if (multi || chkbox || multiClick) {
-      if ((event as KeyboardEvent).shiftKey) {
-        selected = selectRowsBetween([], this.rows(), index, this.prevIndex!);
+      if ((event as KeyboardEvent).shiftKey && this.prevIndex !== undefined) {
+        const rangeSelection = selectRowsBetween(this.rows(), index, this.prevIndex);
+        selected = [...this.selected()];
+        for (const rangeRow of rangeSelection) {
+          if (this.getRowSelectedIdx(rangeRow, selected) < 0) {
+            selected.push(rangeRow);
+          }
+        }
       } else if (
         (event as KeyboardEvent).key === 'a' &&
         ((event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey)

--- a/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/body.component.ts
@@ -99,12 +99,14 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
         [class.horizontal-overflow]="innerWidth() < (columnGroupWidths?.total ?? 0)"
         (scroll)="onBodyScroll($event)"
       >
-        @if (summaryRow() && summaryPosition() === 'top') {
+        @if ((summaryRow() || summaryRowTemplate()) && summaryPosition() === 'top') {
           <datatable-summary-row
+            [class.sticky]="summaryRowTemplate()"
             [rowHeight]="summaryHeight()"
             [innerWidth]="innerWidth()"
             [rows]="rows"
             [columns]="columns"
+            [template]="summaryRowTemplate()"
           />
         }
         <ng-template
@@ -233,12 +235,13 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
           }
         </div>
       </datatable-scroller>
-      @if (summaryRow() && summaryPosition() === 'bottom') {
+      @if ((summaryRow() || summaryRowTemplate()) && summaryPosition() === 'bottom') {
         <datatable-summary-row
           [rowHeight]="summaryHeight()"
           [innerWidth]="innerWidth()"
           [rows]="rows"
           [columns]="columns"
+          [template]="summaryRowTemplate()"
         />
       }
     }
@@ -290,6 +293,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   readonly summaryRow = input<boolean>();
   readonly summaryPosition = input.required<string>();
   readonly summaryHeight = input.required<number>();
+  readonly summaryRowTemplate = input<TemplateRef<void>>();
   readonly rowDraggable = input<boolean>();
   readonly rowDragEvents = input.required<OutputEmitterRef<DragEventData>>();
   readonly disableRowCheck = input<(row: TRow) => boolean | undefined>();

--- a/projects/swimlane/ngx-datatable/src/lib/components/body/client-side-scrolling.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/client-side-scrolling.spec.ts
@@ -275,7 +275,7 @@ describe('Client-side Scrolling – DatatableComponent.scrollToRow', () => {
 
     it('should call expandToRow for a non-visible child row', async () => {
       datatable.scrollToRow(treeRows[3]);
-      await fixture.whenStable();
+      await vi.waitFor(() => expect(bodyEl.scrollTop).toBeCloseTo(expectedOffset(2)));
 
       // expandToRow should expand the ancestors needed to reveal the target leaf row,
       // but must not flip the leaf itself away from 'disabled'.
@@ -293,6 +293,42 @@ describe('Client-side Scrolling – DatatableComponent.scrollToRow', () => {
       expect(() => datatable.scrollToRow(treeRows[0])).toThrowError(
         'Vertical scrolling is not enabled.'
       );
+    });
+
+    it('should scroll past the original scrollHeight after expanding a parent with many children', async () => {
+      // Build a tree where expanding Row 1 reveals 30 new children. Before expansion,
+      // the visible row count is small (5 roots) and the scroll container therefore has
+      // a scrollHeight equal to ~5 rows. After expansion the rendered DOM grows to
+      // ~35 rows, so the scroll container's scrollHeight must be large enough to reach
+      // the deeply nested target row.
+      const manyChildren: TreeRow[] = Array.from({ length: 30 }, (_, i) => ({
+        id: 100 + i,
+        parentId: 1,
+        name: `Child ${i}`,
+        treeStatus: 'disabled'
+      }));
+      const largeTree: TreeRow[] = [
+        { id: 1, parentId: null, name: 'Row 1', treeStatus: 'collapsed' },
+        ...manyChildren,
+        { id: 2, parentId: null, name: 'Row 2', treeStatus: 'disabled' },
+        { id: 3, parentId: null, name: 'Row 3', treeStatus: 'disabled' },
+        { id: 4, parentId: null, name: 'Row 4', treeStatus: 'disabled' },
+        { id: 5, parentId: null, name: 'Row 5', treeStatus: 'disabled' }
+      ];
+      rowsSig.set(largeTree);
+      await fixture.whenStable();
+
+      // Constrain the viewport so a scrollTop > 0 is required to reveal the target row.
+      bodyEl.style.height = '200px';
+      await fixture.whenStable();
+
+      // Pick the last child of Row 1 – it is not visible yet (Row 1 is collapsed) and
+      // its rendered position is well beyond the pre-expansion scrollHeight.
+      const target = manyChildren[manyChildren.length - 1];
+      datatable.scrollToRow(target, { block: 'start' });
+
+      // Tree order after expansion: Row 1, Child 0..29, Row 2..5 → target index = 30.
+      await vi.waitFor(() => expect(bodyEl.scrollTop).toBeCloseTo(expectedOffset(30)));
     });
   });
 });

--- a/projects/swimlane/ngx-datatable/src/lib/components/body/summary/summary-row.component.scss
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/summary/summary-row.component.scss
@@ -1,0 +1,7 @@
+:host {
+  &.sticky {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+  }
+}

--- a/projects/swimlane/ngx-datatable/src/lib/components/body/summary/summary-row.component.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/summary/summary-row.component.spec.ts
@@ -1,5 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ComponentRef } from '@angular/core';
+import { Component, ComponentRef, TemplateRef, viewChild } from '@angular/core';
 import { ComponentFixture, ComponentFixtureAutoDetect, TestBed } from '@angular/core/testing';
 
 import { TableColumnInternal } from '../../../types/internal.types';
@@ -156,5 +156,41 @@ describe('DataTableSummaryRowComponent', () => {
         expect(col1Text).toBe(transformed);
       });
     });
+  });
+});
+
+@Component({
+  imports: [DataTableSummaryRowComponent],
+  template: `
+    <datatable-summary-row
+      [rows]="rows"
+      [columns]="columns"
+      [rowHeight]="30"
+      [innerWidth]="100"
+      [template]="tpl()"
+    />
+    <ng-template #summaryTpl>
+      <span class="custom-content">Custom summary content</span>
+    </ng-template>
+  `
+})
+class TestHostComponent {
+  rows = [{ col1: 10 }];
+  columns: TableColumnInternal[] = toInternalColumn([{ prop: 'col1' }]);
+  readonly tpl = viewChild<TemplateRef<void>>('summaryTpl');
+}
+
+describe('DataTableSummaryRowComponent with template', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    fixture = TestBed.createComponent(TestHostComponent);
+    await fixture.whenStable();
+  });
+
+  it('should render custom template content instead of computed columns', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('.custom-content')?.textContent).toBe('Custom summary content');
+    expect(el.querySelector('datatable-body-row')).toBeNull();
   });
 });

--- a/projects/swimlane/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, input, TemplateRef } from '@angular/core';
 
 import { TableColumnInternal } from '../../../types/internal.types';
 import { DataTableBodyRowComponent } from '../body-row.component';
@@ -22,21 +23,31 @@ const noopSumFunc = (cells: any[]): void => {
 
 @Component({
   selector: 'datatable-summary-row',
-  imports: [DataTableBodyRowComponent],
+  imports: [DataTableBodyRowComponent, NgTemplateOutlet],
   template: `
-    @let summaryRow = this.summaryRow();
-    @let _internalColumns = this._internalColumns();
-    @if (summaryRow && _internalColumns.length) {
-      <datatable-body-row
-        ariaRowCheckboxMessage=""
-        [columns]="_internalColumns"
-        [rowHeight]="rowHeight()"
-        [row]="summaryRow"
-        [rowIndex]="{ index: -1 }"
-        [cssClasses]="{}"
-      />
+    @let template = this.template();
+    @if (template) {
+      <div class="datatable-body-row" role="row" [style.height.px]="rowHeight()">
+        <div class="datatable-body-cell" role="cell">
+          <ng-container [ngTemplateOutlet]="template" />
+        </div>
+      </div>
+    } @else {
+      @let summaryRow = this.summaryRow();
+      @let _internalColumns = this._internalColumns();
+      @if (summaryRow && _internalColumns.length) {
+        <datatable-body-row
+          ariaRowCheckboxMessage=""
+          [columns]="_internalColumns"
+          [rowHeight]="rowHeight()"
+          [row]="summaryRow"
+          [rowIndex]="{ index: -1 }"
+          [cssClasses]="{}"
+        />
+      }
     }
   `,
+  styleUrl: './summary-row.component.scss',
   changeDetection: ChangeDetectionStrategy.Eager,
   host: {
     class: 'datatable-summary-row'
@@ -48,6 +59,7 @@ export class DataTableSummaryRowComponent {
 
   readonly rowHeight = input.required<number>();
   readonly innerWidth = input.required<number>();
+  readonly template = input<TemplateRef<void>>();
 
   protected readonly _internalColumns = computed(() => {
     return this.columns().map(col => ({

--- a/projects/swimlane/ngx-datatable/src/lib/components/body/summary/summary-row.directive.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/body/summary/summary-row.directive.ts
@@ -1,0 +1,27 @@
+import { Directive, inject, TemplateRef } from '@angular/core';
+
+/**
+ * Directive that provides custom content for the summary row.
+ * When applied, the summary row renders the provided template instead of
+ * computing per-column aggregate values, enabling use cases like summary action bars.
+ *
+ * The row is rendered with sticky positioning at the top of the datatable body.
+ *
+ * @example
+ * ```html
+ * <ngx-datatable [rows]="rows" selectionType="checkbox" [(selected)]="selected">
+ *   @if (selected.length) {
+ *     <ng-template ngx-datatable-summary-row>
+ *       <span>{{ selected.length }} selected</span>
+ *       <button (click)="delete()">Delete</button>
+ *     </ng-template>
+ *   }
+ * </ngx-datatable>
+ * ```
+ */
+@Directive({
+  selector: '[ngx-datatable-summary-row]'
+})
+export class DatatableSummaryRowDirective {
+  readonly template = inject(TemplateRef<void>);
+}

--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.html
@@ -59,6 +59,7 @@
       [summaryRow]="summaryRow()"
       [summaryHeight]="summaryHeight()"
       [summaryPosition]="summaryPosition()"
+      [summaryRowTemplate]="summaryRowDirective()?.template"
       [verticalScrollVisible]="verticalScrollVisible"
       [ariaRowCheckboxMessage]="messages().ariaRowCheckboxMessage ?? 'Select row'"
       [ariaGroupHeaderCheckboxMessage]="

--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.spec.ts
@@ -584,6 +584,113 @@ describe('DatatableComponent With Custom Templates', () => {
   });
 });
 
+describe('DatatableComponent With Ghost Loading', () => {
+  @Component({
+    imports: [DatatableComponent],
+    template: `
+      <ngx-datatable
+        columnMode="force"
+        [rows]="rows()"
+        [columns]="columns()"
+        [scrollbarV]="scrollbarV()"
+        [ghostLoadingIndicator]="ghostLoadingIndicator()"
+        [rowHeight]="rowHeight()"
+        [headerHeight]="headerHeight()"
+      />
+    `,
+    host: {
+      '[style.inline-size.px]': 'size()',
+      '[style.block-size.px]': 'height()'
+    }
+  })
+  class TestFixtureWithGhostLoadingComponent {
+    readonly columns = signal<TableColumn[]>([{ prop: 'name' }]);
+    readonly rows = signal<Record<string, any>[]>([]);
+    readonly scrollbarV = signal(true);
+    readonly ghostLoadingIndicator = signal(false);
+    readonly rowHeight = signal(50);
+    readonly headerHeight = signal(50);
+    readonly size = signal(400);
+    readonly height = signal(600);
+  }
+
+  let fixture: ComponentFixture<TestFixtureWithGhostLoadingComponent>;
+  let component: TestFixtureWithGhostLoadingComponent;
+  let datatable: DatatableComponent;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestFixtureWithGhostLoadingComponent);
+    component = fixture.componentInstance;
+    datatable = fixture.debugElement.query(By.directive(DatatableComponent)).componentInstance;
+  });
+
+  it('should push enough undefined rows to fill pageSize when ghost loading with no data', async () => {
+    component.ghostLoadingIndicator.set(true);
+    component.scrollbarV.set(true);
+    component.rows.set([]);
+    await fixture.whenStable();
+
+    const internalRows = datatable._internalRows();
+    const pageSize = datatable.pageSize();
+    const undefinedCount = internalRows.filter(r => r === undefined).length;
+
+    expect(undefinedCount).toBe(Math.max(pageSize, 1));
+  });
+
+  it('should push only one undefined row when data already fills the viewport', async () => {
+    const rows = Array.from({ length: 20 }, (_, i) => ({ name: `Row ${i}` }));
+    component.rows.set(rows);
+    await fixture.whenStable();
+
+    component.ghostLoadingIndicator.set(true);
+    await fixture.whenStable();
+
+    const internalRows = datatable._internalRows();
+    const undefinedCount = internalRows.filter(r => r === undefined).length;
+
+    expect(undefinedCount).toBe(1);
+    expect(internalRows.length).toBe(rows.length + 1);
+  });
+
+  it('should push enough undefined rows to fill remaining viewport when partial data is loaded', async () => {
+    component.ghostLoadingIndicator.set(true);
+    component.scrollbarV.set(true);
+    await fixture.whenStable();
+
+    const pageSize = datatable.pageSize();
+    const partialRows = Array.from({ length: 3 }, (_, i) => ({ name: `Row ${i}` }));
+    component.rows.set(partialRows);
+    await fixture.whenStable();
+
+    const internalRows = datatable._internalRows();
+    const undefinedCount = internalRows.filter(r => r === undefined).length;
+
+    expect(undefinedCount).toBe(Math.max(pageSize - partialRows.length, 1));
+    expect(internalRows.length).toBe(partialRows.length + undefinedCount);
+  });
+
+  it('should not add undefined rows when ghostLoadingIndicator is false', async () => {
+    component.ghostLoadingIndicator.set(false);
+    await fixture.whenStable();
+
+    const internalRows = datatable._internalRows();
+    const undefinedCount = internalRows.filter(r => r === undefined).length;
+
+    expect(undefinedCount).toBe(0);
+  });
+
+  it('should not add undefined rows when scrollbarV is false', async () => {
+    component.ghostLoadingIndicator.set(true);
+    component.scrollbarV.set(false);
+    await fixture.whenStable();
+
+    const internalRows = datatable._internalRows();
+    const undefinedCount = internalRows.filter(r => r === undefined).length;
+
+    expect(undefinedCount).toBe(0);
+  });
+});
+
 describe('DatatableComponent With Frozen columns', () => {
   @Component({
     changeDetection: ChangeDetectionStrategy.Eager,

--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
@@ -1207,7 +1207,7 @@ export class DatatableComponent<TRow extends Row = any>
       optionalGetterForProp(this.treeToRelation())
     );
     this._rowDiffCount.update(v => v + 1);
-    // We need a microTask here to let Angular update the DOM
-    queueMicrotask(() => this.scrollToRowTree(row, options, true));
+    // We need a setTimeout to wait until the DOM was updated
+    setTimeout(() => this.scrollToRowTree(row, options, true));
   }
 }

--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
@@ -483,7 +483,7 @@ export class DatatableComponent<TRow extends Row = any>
    * <ngx-datatable [(sorts)]="mySorts"></ngx-datatable>
    * ```
    *
-   * When using `(sort)/(sortsChange)` and `(page)` together (typically server-side paging),
+   * When using `(sort)`/`(sortsChange)` and `(page)` together (typically for server-side paging),
    * subscribe only to `(page)` and read {@link PageEvent.sorts} from the event payload instead.
    * `(page)` emits on both page changes and sort changes.
    */

--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
@@ -482,6 +482,10 @@ export class DatatableComponent<TRow extends Row = any>
    * <!-- or -->
    * <ngx-datatable [(sorts)]="mySorts"></ngx-datatable>
    * ```
+   *
+   * When using `(sort)/(sortsChange)` and `(page)` together (typically server-side paging),
+   * subscribe only to `(page)` and read {@link PageEvent.sorts} from the event payload instead.
+   * `(page)` emits on both page changes and sort changes.
    */
   readonly sort = output<SortEvent>();
 

--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
@@ -69,6 +69,7 @@ import { DatatableGroupHeaderDirective } from './body/body-group-header.directiv
 import { DatatableRowDefDirective } from './body/body-row-def.component';
 import { DataTableBodyComponent } from './body/body.component';
 import { ProgressBarComponent } from './body/progress-bar.component';
+import { DatatableSummaryRowDirective } from './body/summary/summary-row.directive';
 import { DataTableColumnDirective } from './columns/column.directive';
 import { DataTableFooterComponent } from './footer/footer.component';
 import { DatatableFooterDirective } from './footer/footer.directive';
@@ -541,6 +542,11 @@ export class DatatableComponent<TRow extends Row = any>
    */
   @ContentChild(DatatableGroupHeaderDirective)
   groupHeader?: DatatableGroupHeaderDirective;
+
+  /**
+   * Custom summary row template gathered from the ContentChild
+   */
+  readonly summaryRowDirective = contentChild(DatatableSummaryRowDirective);
 
   /**
    * Footer template gathered from the ContentChild

--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
@@ -485,7 +485,7 @@ export class DatatableComponent<TRow extends Row = any>
    *
    * When using `(sort)`/`(sortsChange)` and `(page)` together (typically for server-side paging),
    * subscribe only to `(page)` and read {@link PageEvent.sorts} from the event payload instead.
-   * `(page)` emits on both page changes and sort changes.
+   * `(page)` emits on both page and sort changes.
    */
   readonly sort = output<SortEvent>();
 

--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
@@ -585,6 +585,10 @@ export class DatatableComponent<TRow extends Row = any>
   element = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;
   readonly _innerWidth = computed(() => this.dimensions().width);
   readonly pageSize = computed(() => this.calcPageSize());
+  private readonly viewportRowCount = computed(() => {
+    const size = Math.ceil(this.bodyHeight() / (this.rowHeight() as number));
+    return Math.max(size, 0);
+  });
   readonly _isFixedHeader = computed(() => {
     const headerHeight: number | string = this.headerHeight();
     return typeof headerHeight === 'string' ? (headerHeight as string) !== 'auto' : true;
@@ -624,8 +628,10 @@ export class DatatableComponent<TRow extends Row = any>
     }
 
     if (this.ghostLoadingIndicator() && this.scrollbarV() && !this.externalPaging()) {
-      // in case where we don't have predefined total page length
-      rows.push(undefined); // undefined row will render ghost cell row at the end of the page
+      const ghostRowCount = Math.max(this.viewportRowCount() - rows.length, 1);
+      for (let i = 0; i < ghostRowCount; i++) {
+        rows.push(undefined);
+      }
     }
 
     return rows;
@@ -939,12 +945,8 @@ export class DatatableComponent<TRow extends Row = any>
    * Recalculates the sizes of the page
    */
   calcPageSize(): number {
-    // Keep the page size constant even if the row has been expanded.
-    // This is because an expanded row is still considered to be a child of
-    // the original row.  Hence calculation would use rowHeight only.
     if (this.scrollbarV() && this.virtualization()) {
-      const size = Math.ceil(this.bodyHeight() / (this.rowHeight() as number));
-      return Math.max(size, 0);
+      return this.viewportRowCount();
     }
 
     // if limit is passed, we are paging

--- a/projects/swimlane/ngx-datatable/src/lib/components/header/header-cell.component.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/header/header-cell.component.spec.ts
@@ -216,13 +216,13 @@ describe('DataTableHeaderCellComponent - custom sort icons', () => {
     await harness.applySort();
     await fixture.whenStable();
 
-    const sortBtn = fixture.nativeElement.querySelector('.sort-btn');
+    const sortBtn: HTMLElement = fixture.nativeElement.querySelector('.sort-btn');
 
-    expect(sortBtn).toHaveClass('sort-btn');
-    expect(sortBtn).toHaveClass('sort-asc');
-    expect(sortBtn).toHaveClass('icon');
-    expect(sortBtn).toHaveClass('up');
-    expect(sortBtn).not.toHaveClass('datatable-icon-up');
+    expect(sortBtn.classList.contains('sort-btn')).toBe(true);
+    expect(sortBtn.classList.contains('sort-asc')).toBe(true);
+    expect(sortBtn.classList.contains('icon')).toBe(true);
+    expect(sortBtn.classList.contains('up')).toBe(true);
+    expect(sortBtn.classList.contains('datatable-icon-up')).toBe(false);
   });
 
   it('should apply custom sortDescendingIcon class when toggling to descending sort', async () => {
@@ -231,11 +231,11 @@ describe('DataTableHeaderCellComponent - custom sort icons', () => {
     await harness.applySort();
     await fixture.whenStable();
 
-    const sortButton = fixture.nativeElement.querySelector('.sort-btn');
-    expect(sortButton).toHaveClass('sort-btn');
-    expect(sortButton).toHaveClass('sort-desc');
-    expect(sortButton).toHaveClass('icon');
-    expect(sortButton).toHaveClass('down');
-    expect(sortButton).not.toHaveClass('datatable-icon-down');
+    const sortButton: HTMLElement = fixture.nativeElement.querySelector('.sort-btn');
+    expect(sortButton.classList.contains('sort-btn')).toBe(true);
+    expect(sortButton.classList.contains('sort-desc')).toBe(true);
+    expect(sortButton.classList.contains('icon')).toBe(true);
+    expect(sortButton.classList.contains('down')).toBe(true);
+    expect(sortButton.classList.contains('datatable-icon-down')).toBe(false);
   });
 });

--- a/projects/swimlane/ngx-datatable/src/lib/components/header/header-cell.component.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/header/header-cell.component.spec.ts
@@ -3,9 +3,12 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  inputBinding,
+  outputBinding,
   signal,
   TemplateRef,
-  viewChild
+  viewChild,
+  WritableSignal
 } from '@angular/core';
 import { ComponentFixture, ComponentFixtureAutoDetect, TestBed } from '@angular/core/testing';
 
@@ -14,6 +17,7 @@ import {
   SortableTableColumnInternal,
   TableColumnInternal
 } from '../../types/internal.types';
+import { SortPropDir } from '../../types/public.types';
 import { toInternalColumn } from '../../utils/column-helper';
 import { DataTableHeaderCellComponent } from './header-cell.component';
 import { HeaderCellHarness } from './testing/header-cell.harnes';
@@ -168,5 +172,70 @@ describe('DataTableHeaderCellComponent with template', () => {
       prevValue: undefined,
       newValue: 'asc'
     });
+  });
+});
+
+describe('DataTableHeaderCellComponent - custom sort icons', () => {
+  let fixture: ComponentFixture<DataTableHeaderCellComponent>;
+  let harness: HeaderCellHarness;
+  let sorts: WritableSignal<SortPropDir[]>;
+  const column = signal({
+    name: 'test',
+    prop: 'test',
+    sortable: true,
+    resizeable: false,
+    width: signal(20)
+  });
+  const sortAscendingIcon = signal('icon up');
+  const sortDescendingIcon = signal('icon down');
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: ComponentFixtureAutoDetect, useValue: false }]
+    });
+    sorts = signal<SortPropDir[]>([]);
+    fixture = TestBed.createComponent(DataTableHeaderCellComponent, {
+      bindings: [
+        inputBinding('sortType', () => 'single'),
+        inputBinding('ariaHeaderCheckboxMessage', () => 'Select All'),
+        inputBinding('sortAscendingIcon', sortAscendingIcon),
+        inputBinding('sortDescendingIcon', sortDescendingIcon),
+        inputBinding('column', column),
+        inputBinding('sorts', sorts),
+        inputBinding('showResizeHandle', () => false),
+        outputBinding('sort', (event: InnerSortEvent) => {
+          sorts.set([{ prop: event.column.prop!, dir: event.newValue! }]);
+        })
+      ]
+    });
+    fixture.autoDetectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, HeaderCellHarness);
+  });
+
+  it('should apply custom sortAscendingIcon class when toggling to ascending sort', async () => {
+    await harness.applySort();
+    await fixture.whenStable();
+
+    const sortBtn = fixture.nativeElement.querySelector('.sort-btn');
+
+    expect(sortBtn).toHaveClass('sort-btn');
+    expect(sortBtn).toHaveClass('sort-asc');
+    expect(sortBtn).toHaveClass('icon');
+    expect(sortBtn).toHaveClass('up');
+    expect(sortBtn).not.toHaveClass('datatable-icon-up');
+  });
+
+  it('should apply custom sortDescendingIcon class when toggling to descending sort', async () => {
+    await harness.applySort();
+    await fixture.whenStable();
+    await harness.applySort();
+    await fixture.whenStable();
+
+    const sortButton = fixture.nativeElement.querySelector('.sort-btn');
+    expect(sortButton).toHaveClass('sort-btn');
+    expect(sortButton).toHaveClass('sort-desc');
+    expect(sortButton).toHaveClass('icon');
+    expect(sortButton).toHaveClass('down');
+    expect(sortButton).not.toHaveClass('datatable-icon-down');
   });
 });

--- a/projects/swimlane/ngx-datatable/src/lib/components/header/header-cell.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/header/header-cell.component.ts
@@ -142,9 +142,9 @@ export class DataTableHeaderCellComponent implements OnInit, OnDestroy {
 
   protected readonly isCheckboxable = computed(() => this.column().headerCheckboxable);
 
-  protected readonly sortClass = computed<string[] | undefined>(() => {
-    return this.calcSortClass(this.sortDir());
-  });
+  protected readonly sortClass = computed<string | undefined>(() =>
+    this.calcSortClass(this.sortDir())
+  );
   protected readonly sortDir = computed<SortDirection | undefined>(() => {
     return this.calcSortDir(this.sorts());
   });
@@ -217,16 +217,20 @@ export class DataTableHeaderCellComponent implements OnInit, OnDestroy {
     });
   }
 
-  calcSortClass(sortDir: SortDirection | undefined): string[] | undefined {
+  calcSortClass(sortDir: SortDirection | undefined): string | undefined {
     if (!this.cellContext().column.sortable) {
       return undefined;
     }
-    if (sortDir === 'asc') {
-      return ['sort-btn', 'sort-asc', this.sortAscendingIcon() ?? 'datatable-icon-up'];
-    } else if (sortDir === 'desc') {
-      return ['sort-btn', 'sort-desc', this.sortDescendingIcon() ?? 'datatable-icon-down'];
-    } else {
-      return ['sort-btn', this.sortUnsetIcon() ?? 'datatable-icon-sort-unset'];
+
+    const base = 'sort-btn';
+
+    switch (sortDir) {
+      case 'asc':
+        return `${base} sort-asc ${this.sortAscendingIcon() ?? 'datatable-icon-up'}`;
+      case 'desc':
+        return `${base} sort-desc ${this.sortDescendingIcon() ?? 'datatable-icon-down'}`;
+      default:
+        return `${base} ${this.sortUnsetIcon() ?? 'datatable-icon-sort-unset'}`;
     }
   }
 

--- a/projects/swimlane/ngx-datatable/src/lib/components/header/header-cell.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/header/header-cell.component.ts
@@ -68,7 +68,7 @@ import { nextSortDir } from '../../utils/sort';
           </span>
         </span>
       }
-      <span [class]="sortClass()" (click)="onSort()"> </span>
+      <span aria-hidden="true" [class]="sortClass()" (click)="onSort()"> </span>
     </div>
     @if (showResizeHandle()) {
       <span
@@ -87,6 +87,7 @@ import { nextSortDir } from '../../utils/sort';
     '[attr.resizeable]': 'showResizeHandle()',
     '[attr.title]': 'name()',
     '[attr.tabindex]': 'column().sortable ? 0 : -1',
+    '[attr.aria-sort]': 'ariaSort()',
     '[class]': 'columnCssClasses()',
     '[class.sortable]': 'column().sortable',
     '[class.resizeable]': 'showResizeHandle()',
@@ -147,6 +148,20 @@ export class DataTableHeaderCellComponent implements OnInit, OnDestroy {
   );
   protected readonly sortDir = computed<SortDirection | undefined>(() => {
     return this.calcSortDir(this.sorts());
+  });
+
+  protected readonly ariaSort = computed(() => {
+    if (!this.column().sortable) {
+      return null;
+    }
+    switch (this.sortDir()) {
+      case 'asc':
+        return 'ascending';
+      case 'desc':
+        return 'descending';
+      default:
+        return 'none';
+    }
   });
 
   protected readonly cellContext = computed<HeaderCellContext>(() => {

--- a/projects/swimlane/ngx-datatable/src/lib/components/header/header.component.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/header/header.component.spec.ts
@@ -31,6 +31,10 @@ describe('DataTableHeaderComponent', () => {
     componentRef = fixture.componentRef;
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should render with given column headers', async () => {
     componentRef.setInput(
       'columns',
@@ -55,7 +59,6 @@ describe('DataTableHeaderComponent', () => {
     // there is setTimeout in columns setter so we need to wait for it
     vi.advanceTimersByTime(0);
     expect(await harness.getHeaderRowWidth()).toBeCloseTo(500);
-    vi.useRealTimers();
   });
 
   it('should place header cells based on column pinning group', async () => {
@@ -250,8 +253,6 @@ describe('DataTableHeaderComponent', () => {
     expect(await harness.getColumnName(0)).toBe('Column 2');
     expect(await harness.getColumnName(1)).toBe('Column 1');
     expect(await harness.getColumnName(2)).toBe('Column 3');
-
-    vi.useRealTimers();
   });
 
   it('should not apply translateX to center group (scroll sync via native scrollLeft)', async () => {

--- a/projects/swimlane/ngx-datatable/src/lib/directives/datatable-draggable.directive.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/directives/datatable-draggable.directive.ts
@@ -56,9 +56,11 @@ export class DatatableDraggableDirective implements OnDestroy {
       if (this.enabled()) {
         this.element.addEventListener('mousedown', this.mousedown);
         this.element.addEventListener('touchstart', this.touchstart);
+        this.element.addEventListener('contextmenu', this.contextmenu);
         this.removePointerListeners = () => {
           this.element.removeEventListener('mousedown', this.mousedown);
           this.element.removeEventListener('touchstart', this.touchstart);
+          this.element.removeEventListener('contextmenu', this.contextmenu);
         };
       } else {
         this.removePointerListeners?.();
@@ -83,30 +85,44 @@ export class DatatableDraggableDirective implements OnDestroy {
     this.delay(this.dragStartDelay()).then(() => {
       this.document.addEventListener('mousemove', this.mousemove);
       this.starting(event.clientX, event.clientY);
+      this.setDragging(true);
     });
   };
 
   private mousemove = (event: MouseEvent): void => this.moving(event.clientX, event.clientY);
+
+  // Prevent context menu on long-press drag. Since we don't call preventDefault() on
+  // touchstart to allow click events (sorting), the browser would show a context menu
+  // after a long press. We prevent this when dragging is active.
+  private contextmenu = (event: MouseEvent): void => {
+    if (this.isDragging()) {
+      event.preventDefault();
+    }
+  };
 
   protected readonly touchstart = (event: TouchEvent): void => {
     if (!this.enabled()) {
       return;
     }
     event.stopPropagation();
-    event.preventDefault();
     const touch = event.touches.item(0)!;
     this.touchId = touch.identifier;
 
     this.document.addEventListener('touchend', this.ending);
     this.delay(this.dragStartDelay()).then(() => {
-      this.document.addEventListener('touchmove', this.touchmove);
-      this.starting(touch.clientX, touch.clientY);
+      if (this.touchId === touch.identifier) {
+        this.document.addEventListener('touchmove', this.touchmove, { passive: false });
+        this.starting(touch.clientX, touch.clientY);
+        this.setDragging(true);
+      }
     });
   };
 
   private touchmove = (event: TouchEvent): void => {
-    const touchMove = this.findTouch(event)!;
+    const touchMove = this.findTouch(event);
     if (touchMove) {
+      // Prevent scrolling and other default touch behaviors during drag
+      event.preventDefault();
       this.moving(touchMove.clientX, touchMove.clientY);
     }
   };
@@ -139,9 +155,17 @@ export class DatatableDraggableDirective implements OnDestroy {
     // This function is also called if the long press was aborted before the delay.
     // In that case, we don't want to emit dragEnd.
     if (dragged) {
+      this.setDragging(false);
       this.dragEnd.emit();
     }
   };
+
+  private setDragging(dragging: boolean): void {
+    const model = this.dragModel();
+    if (model) {
+      model.dragging = dragging;
+    }
+  }
 
   private findTouch(event: TouchEvent): Touch | undefined {
     return Array.from(event.touches).find(touch => touch.identifier === this.touchId);

--- a/projects/swimlane/ngx-datatable/src/lib/directives/draggable.directive.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/directives/draggable.directive.spec.ts
@@ -162,13 +162,16 @@ describe('DraggableDirective', () => {
       await fixture.whenStable();
     });
 
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it('should start dragging after the specified delay', async () => {
       vi.useFakeTimers();
       await harness.touchStart(0);
       vi.advanceTimersByTime(100);
       await fixture.whenStable();
       expect(dragStartSpy).toHaveBeenCalled();
-      vi.useRealTimers();
     });
 
     it('should skip dragging if not pressed long enough', async () => {
@@ -178,7 +181,6 @@ describe('DraggableDirective', () => {
       await harness.mouseUp();
       expect(dragStartSpy).not.toHaveBeenCalled();
       expect(dragEndSpy).not.toHaveBeenCalled();
-      vi.useRealTimers();
     });
 
     it('should not start dragging if waiting for the delay', async () => {
@@ -187,7 +189,14 @@ describe('DraggableDirective', () => {
       vi.advanceTimersByTime(50);
       await harness.mouseMove(100);
       expect(dragMoveSpy).not.toHaveBeenCalled();
-      vi.useRealTimers();
+    });
+
+    it('should not start dragging after short touch before delay', async () => {
+      vi.useFakeTimers();
+      await harness.touchStart(0);
+      vi.advanceTimersByTime(50);
+      await harness.touchEnd();
+      expect(dragStartSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/projects/swimlane/ngx-datatable/src/lib/ngx-datatable.module.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/ngx-datatable.module.ts
@@ -6,6 +6,7 @@ import {
   DatatableRowDefComponent,
   DatatableRowDefDirective
 } from './components/body/body-row-def.component';
+import { DatatableSummaryRowDirective } from './components/body/summary/summary-row.directive';
 import { DataTableColumnCellDirective } from './components/columns/column-cell.directive';
 import { DataTableColumnGhostCellDirective } from './components/columns/column-ghost-cell.directive';
 import { DataTableColumnHeaderDirective } from './components/columns/column-header.directive';
@@ -37,7 +38,8 @@ import { AllPartial, NgxDatatableConfig, providedNgxDatatableConfig } from './ng
     DatatableGroupHeaderTemplateDirective,
     DisableRowDirective,
     DatatableRowDefComponent,
-    DatatableRowDefDirective
+    DatatableRowDefDirective,
+    DatatableSummaryRowDirective
   ],
   exports: [
     DatatableComponent,
@@ -55,7 +57,8 @@ import { AllPartial, NgxDatatableConfig, providedNgxDatatableConfig } from './ng
     DatatableGroupHeaderTemplateDirective,
     DisableRowDirective,
     DatatableRowDefComponent,
-    DatatableRowDefDirective
+    DatatableRowDefDirective,
+    DatatableSummaryRowDirective
   ]
 })
 export class NgxDatatableModule {

--- a/projects/swimlane/ngx-datatable/src/lib/utils/selection.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/utils/selection.ts
@@ -11,12 +11,12 @@ export const selectRows = <TRow>(selected: TRow[], row: TRow, comparefn: any) =>
 };
 
 export const selectRowsBetween = <TRow>(
-  selected: TRow[],
   rows: (TRow | undefined)[],
   index: number,
   prevIndex: number
 ): TRow[] => {
   const reverse = index < prevIndex;
+  const rangeRows: TRow[] = [];
 
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
@@ -37,13 +37,11 @@ export const selectRowsBetween = <TRow>(
     }
 
     if ((reverse && lesser) || (!reverse && greater)) {
-      // if in the positive range to be added to `selected`, and
-      // not already in the selected array, add it
       if (i >= range.start && i <= range.end && row) {
-        selected.push(row);
+        rangeRows.push(row);
       }
     }
   }
 
-  return selected;
+  return rangeRows;
 };

--- a/projects/swimlane/ngx-datatable/src/lib/utils/tree.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/utils/tree.spec.ts
@@ -1,0 +1,130 @@
+import { groupRowsByParents, optionalGetterForProp } from './tree';
+
+interface TreeRow {
+  id: number;
+  parentId: number;
+  level?: number;
+  treeStatus?: 'expanded' | 'collapsed' | 'disabled' | 'loading';
+}
+
+const fromGetter = optionalGetterForProp('parentId');
+const toGetter = optionalGetterForProp('id');
+
+const expanded = (row: Partial<TreeRow>): TreeRow =>
+  ({ treeStatus: 'expanded', ...row }) as TreeRow;
+
+describe('groupRowsByParents', () => {
+  it('should compute level=0 for root rows and level=1 for direct children when parent precedes child', () => {
+    const rows: TreeRow[] = [expanded({ id: 1, parentId: 0 }), expanded({ id: 2, parentId: 1 })];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    expect(result.map(r => r.id)).toEqual([1, 2]);
+    expect(result[0].level).toBe(0);
+    expect(result[1].level).toBe(1);
+  });
+
+  it('should compute correct level when a child appears before its parent in the input array', () => {
+    // Regression: previously produced level = NaN for the child.
+    const rows: TreeRow[] = [expanded({ id: 2, parentId: 1 }), expanded({ id: 1, parentId: 0 })];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    for (const row of result) {
+      expect(Number.isNaN(row.level)).toBe(false);
+      expect(typeof row.level).toBe('number');
+    }
+
+    const byId = new Map(result.map(r => [r.id, r]));
+    expect(byId.get(1)!.level).toBe(0);
+    expect(byId.get(2)!.level).toBe(1);
+  });
+
+  it('should compute correct levels for arbitrarily ordered deep trees', () => {
+    // Tree:
+    //   1
+    //   ├── 3
+    //   │   └── 6
+    //   └── 4
+    //   2
+    //   └── 5
+    const rows: TreeRow[] = [
+      expanded({ id: 6, parentId: 3 }),
+      expanded({ id: 5, parentId: 2 }),
+      expanded({ id: 3, parentId: 1 }),
+      expanded({ id: 4, parentId: 1 }),
+      expanded({ id: 1, parentId: 0 }),
+      expanded({ id: 2, parentId: 0 })
+    ];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    const byId = new Map(result.map(r => [r.id, r]));
+    expect(byId.get(1)!.level).toBe(0);
+    expect(byId.get(2)!.level).toBe(0);
+    expect(byId.get(3)!.level).toBe(1);
+    expect(byId.get(4)!.level).toBe(1);
+    expect(byId.get(5)!.level).toBe(1);
+    expect(byId.get(6)!.level).toBe(2);
+
+    for (const row of result) {
+      expect(Number.isNaN(row.level)).toBe(false);
+    }
+  });
+
+  it('should treat orphans (parent not in list) as root rows with level=0', () => {
+    const rows: TreeRow[] = [
+      expanded({ id: 7, parentId: 8 }) // parent 8 does not exist
+    ];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe(0);
+  });
+
+  it('should not loop forever on cyclic relationships and should assign finite numeric levels', () => {
+    const rows: TreeRow[] = [expanded({ id: 1, parentId: 2 }), expanded({ id: 2, parentId: 1 })];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    expect(result).toHaveLength(rows.length);
+    for (const row of result) {
+      expect(Number.isFinite(row.level!)).toBe(true);
+      expect(Number.isNaN(row.level)).toBe(false);
+    }
+  });
+
+  it('should return rows unchanged when no from/to getters are provided', () => {
+    const rows: TreeRow[] = [expanded({ id: 2, parentId: 1 }), expanded({ id: 1, parentId: 0 })];
+
+    const result = groupRowsByParents(rows);
+    expect(result).toBe(rows);
+  });
+
+  it('should not include children of collapsed parents in the flattened output', () => {
+    const rows: TreeRow[] = [
+      { id: 1, parentId: 0, treeStatus: 'collapsed' },
+      { id: 2, parentId: 1, treeStatus: 'expanded' }
+    ];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    expect(result.map(r => r.id)).toEqual([1]);
+    // Level should still be assigned correctly even if not rendered.
+    expect(rows[1].level).toBe(1);
+  });
+
+  it('should preserve input-order sibling ordering when a grandchild appears before a sibling', () => {
+    const rows: TreeRow[] = [
+      expanded({ id: 1, parentId: 0 }),
+      expanded({ id: 4, parentId: 1 }),
+      expanded({ id: 3, parentId: 2 }),
+      expanded({ id: 2, parentId: 1 })
+    ];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    expect(result.map(r => r.id)).toEqual([1, 4, 2, 3]);
+  });
+});

--- a/projects/swimlane/ngx-datatable/src/lib/utils/tree.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/utils/tree.ts
@@ -13,7 +13,7 @@ export const optionalGetterForProp = (prop: TableColumnProp | undefined): Option
  *
  * Note: Expecting each item has a property called parentId
  * Note: This algorithm will fail if a list has two or more items with same ID
- * NOTE: This algorithm will fail if there is a deadlock of relationship
+ * Note: Cyclic relationships are broken by treating one node in the cycle as a root
  *
  * For example,
  *
@@ -52,19 +52,48 @@ export const groupRowsByParents = <TRow extends Row>(
     const treeRows = rows.filter(row => !!row).map(row => new TreeNode(row));
     const uniqIDs = new Map(treeRows.map(node => [to(node.row), node]));
 
-    const rootNodes = treeRows.reduce((root, node) => {
-      const fromValue = from(node.row);
-      const parent = uniqIDs.get(fromValue);
-      if (parent) {
-        node.row.level = parent.row.level! + 1; // TODO: should be reflected by type, that level is defined
-        node.parent = parent;
-        parent.children.push(node);
+    const resolved = new Set<TreeNode<TRow>>();
+    const resolveLevel = (node: TreeNode<TRow>, visited: Set<TreeNode<TRow>>): number => {
+      if (resolved.has(node)) {
+        return node.row.level!;
+      }
+      if (visited.has(node)) {
+        return Infinity;
+      }
+      visited.add(node);
+
+      const parent = uniqIDs.get(from(node.row));
+      if (parent && parent !== node) {
+        const parentLevel = resolveLevel(parent, visited);
+        if (parentLevel !== Infinity) {
+          node.row.level = parentLevel + 1;
+        } else {
+          node.row.level = 0;
+        }
       } else {
         node.row.level = 0;
-        root.push(node);
       }
-      return root;
-    }, [] as TreeNode<TRow>[]);
+
+      visited.delete(node);
+      resolved.add(node);
+      return node.row.level;
+    };
+
+    for (const node of treeRows) {
+      if (!resolved.has(node)) {
+        resolveLevel(node, new Set());
+      }
+    }
+
+    for (const node of treeRows) {
+      const parent = uniqIDs.get(from(node.row));
+      if (parent && parent !== node && node.row.level! > 0) {
+        node.parent = parent;
+        parent.children.push(node);
+      }
+    }
+
+    const rootNodes = treeRows.filter(n => !n.parent);
 
     return rootNodes.flatMap(child => child.flatten());
   } else {

--- a/projects/swimlane/ngx-datatable/src/public-api.ts
+++ b/projects/swimlane/ngx-datatable/src/public-api.ts
@@ -18,6 +18,7 @@ export * from './lib/components/columns/tree.directive';
 export * from './lib/components/row-detail/row-detail.directive';
 export * from './lib/components/row-detail/row-detail-template.directive';
 export * from './lib/components/body/body-row-def.component';
+export * from './lib/components/body/summary/summary-row.directive';
 
 // directives
 export * from './lib/directives/disable-row.directive';

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -283,5 +283,10 @@ export const routes: Routes = [
     path: 'inline-html-summary',
     loadComponent: () =>
       import('./summary/inline-html-summary.component').then(c => c.InlineHtmlSummaryComponent)
+  },
+  {
+    path: 'summary-row-actions',
+    loadComponent: () =>
+      import('./summary/summary-row-actions.component').then(c => c.SummaryRowActionsComponent)
   }
 ];

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -234,6 +234,9 @@
           <li>
             <a routerLink="inline-html-summary">Inline HTML Summary</a>
           </li>
+          <li>
+            <a routerLink="summary-row-actions">Summary Row Actions</a>
+          </li>
         </ul>
       </li>
     </ul>

--- a/src/app/summary/summary-row-actions.component.ts
+++ b/src/app/summary/summary-row-actions.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import {
   DataTableColumnDirective,
   DatatableComponent,
@@ -11,6 +11,7 @@ import { DataService } from '../data.service';
 @Component({
   selector: 'summary-row-actions-demo',
   imports: [DatatableComponent, DataTableColumnDirective, DatatableSummaryRowDirective],
+  changeDetection: ChangeDetectionStrategy.Eager,
   template: `
     <div>
       <h3>

--- a/src/app/summary/summary-row-actions.component.ts
+++ b/src/app/summary/summary-row-actions.component.ts
@@ -1,0 +1,103 @@
+import { Component, inject, signal } from '@angular/core';
+import {
+  DataTableColumnDirective,
+  DatatableComponent,
+  DatatableSummaryRowDirective
+} from 'projects/swimlane/ngx-datatable/src/public-api';
+
+import { Employee } from '../data.model';
+import { DataService } from '../data.service';
+
+@Component({
+  selector: 'summary-row-actions-demo',
+  imports: [DatatableComponent, DataTableColumnDirective, DatatableSummaryRowDirective],
+  template: `
+    <div>
+      <h3>
+        Summary Row Actions
+        <small>
+          <a
+            href="https://github.com/swimlane/ngx-datatable/blob/master/src/app/summary/summary-row-actions.component.ts"
+            target="_blank"
+          >
+            Source
+          </a>
+        </small>
+      </h3>
+      @let rows = this.rows();
+      <ngx-datatable
+        class="material selection-row"
+        rowHeight="auto"
+        summaryHeight="auto"
+        columnMode="force"
+        selectionType="checkbox"
+        [rows]="rows"
+        [headerHeight]="50"
+        [footerHeight]="50"
+        [limit]="10"
+        [(selected)]="selected"
+      >
+        @if (selected().length) {
+          <ng-template ngx-datatable-summary-row>
+            <div class="summary-row-actions-bar">
+              <span class="summary-row-actions-count">{{ selected().length }} row(s) selected</span>
+              <div class="summary-row-actions-buttons">
+                <button type="button" (click)="onExport()">Export</button>
+                <button type="button" (click)="onDelete()">Delete</button>
+                <button type="button" (click)="onCancel()">Cancel</button>
+              </div>
+            </div>
+          </ng-template>
+        }
+        <ngx-datatable-column
+          [width]="30"
+          [sortable]="false"
+          [canAutoResize]="false"
+          [draggable]="false"
+          [resizeable]="false"
+          [headerCheckboxable]="true"
+          [checkboxable]="true"
+        />
+        <ngx-datatable-column name="Name" />
+        <ngx-datatable-column name="Gender" />
+        <ngx-datatable-column name="Company" />
+      </ngx-datatable>
+    </div>
+  `,
+  styles: `
+    .summary-row-actions-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .summary-row-actions-buttons {
+      display: flex;
+      gap: 8px;
+    }
+  `
+})
+export class SummaryRowActionsComponent {
+  protected readonly rows = signal<Employee[]>([]);
+  protected readonly selected = signal<Employee[]>([]);
+
+  private dataService = inject(DataService);
+
+  constructor() {
+    this.dataService.load('company.json').subscribe(data => this.rows.set(data));
+  }
+
+  protected onExport() {
+    alert(`Exporting ${this.selected().length} row(s)`);
+  }
+
+  protected onDelete() {
+    const names = this.selected().map(r => r.name);
+    this.rows.update(rows => rows.filter(r => !names.includes(r.name)));
+    this.selected.set([]);
+  }
+
+  protected onCancel() {
+    this.selected.set([]);
+  }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Swimlane `angular-22-upgrade` is missing Siemens product fixes/features landed after the tree-scroll tip (`e1aabe0151`), including ghost-loader viewport fill, tree level/scroll timing, shift-selection after ctrl-click, custom summary-row templates, sort icon / `aria-sort` / mobile reorderable sorting fixes.

**What is the new behavior?**

First stacked Siemens sync PR (PR A) onto `angular-22-upgrade`:

- Fill ghost loader rows to viewport height on initial virtual scroll load
- Defer tree `scrollToRow` until after DOM update (`setTimeout`)
- Correct tree `level` when a child precedes its parent
- Keep prior selection when shift-clicking after ctrl-click
- Add `DatatableSummaryRowDirective` + summary-row-actions demo
- Apply multi-class custom sort icons; add missing `aria-sort`
- Allow sorting on mobile when reorderable is enabled
- Header timer restore to reduce flaky tests

**Intentionally deferred / skipped in this PR**

- Demo CD style ports (`async` pipe / Siemens signals) — Swimlane already uses `signal()` + Eager under zoneless
- `#738` `preserveColumnWidthsOnClone` — depends on CSS-grid subgrid; moves to PR B
- CSS-grid scroll rewrite (PR B), deprecated API removals (PR C), docs polish (PR D)

Upstream sources: siemens/ngx-datatable PRs #653, #677, #679, #680, #683, #684, #704, #710, #720, #754 (+ timer fix from #707 vehicle).

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

**Other information**:

- Path-remapped from `projects/ngx-datatable` → `projects/swimlane/ngx-datatable`
- Verified: `yarn build:lib`, `yarn test:ci`, `yarn lint`
- Part of Siemens sync sequence: A (this) → B (css-grid) → C (breaking APIs) → D (docs)

Made with [Cursor](https://cursor.com)