### PR TITLE
(release): 25.0.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## HEAD (unreleased)
+## 25.0.0
 
 ### Features
 

--- a/projects/ngx-datatable/package.json
+++ b/projects/ngx-datatable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-datatable",
-  "version": "24.0.0",
+  "version": "25.0.0",
   "description": "ngx-datatable is an Angular table grid component for presenting large and complex data.",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Release version bump for Angular 22 + Siemens product sync

**What is the current behavior?** (You can also link to an open issue here)

Package version was still `24.0.0` / changelog under `HEAD (unreleased)` after the Angular 22 upgrade and Siemens sync landed on master. Publishable lib package at `projects/swimlane/ngx-datatable` is already `25.0.0`.

**What is the new behavior?**

- Bumps `@swimlane/ngx-datatable` version in `projects/ngx-datatable/package.json` to `25.0.0`
- Promotes changelog entry from `HEAD (unreleased)` to `## 25.0.0` (Angular 22 support, CSS-grid scroll rewrite, Siemens sync features/fixes, and breaking API removals)

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications:

This release documents breaking changes already merged on master:
- Dropped support for Angular 19 and earlier
- Removed deprecated `sort` output → use `(sortsChange)` or `[(sorts)]`
- Removed deprecated `select` output → use `(selectedChange)` or `[(selected)]`
- Removed visibility observer; recalculation is driven by `ResizeObserver` / layout

**Other information**:

Publish after merge using the repo release flow (`yarn package`, tag `25.0.0`, `yarn publish`).


Made with [Cursor](https://cursor.com)