### PR TITLE
fix: prevent negative flex-mode column widths from breaking CSS grid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix: Allow sorting on mobile devices when reorderable is enabled
 - Fix: Add missing `aria-sort` on header cells
 - Fix: Fixing scroller Issue in datatable when multiple columns are there in datatable
+- Fix: Prevent flex mode from emitting negative column widths that invalidate CSS `grid-template-columns` (v25+)
 
 ### Breaking Changes
 

--- a/projects/swimlane/ngx-datatable/src/lib/utils/column.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/utils/column.spec.ts
@@ -1,0 +1,26 @@
+import { signal } from '@angular/core';
+
+import { TableColumnInternal } from '../types/internal.types';
+import { emptyStringGetter } from './column-prop-getters';
+import { columnsByPinArr, gridColumnTemplate } from './column';
+import { orderByComparator } from './sort';
+
+describe('gridColumnTemplate', () => {
+  it('should never emit negative px tracks', () => {
+    const columns = [
+      {
+        $$id: 'd',
+        $$valueGetter: emptyStringGetter,
+        $$originalColumn: {},
+        comparator: orderByComparator,
+        prop: 'd',
+        sortable: false,
+        name: 'd',
+        canAutoResize: true,
+        width: signal(-45)
+      }
+    ] as TableColumnInternal[];
+
+    expect(gridColumnTemplate(columnsByPinArr(columns))).toBe('0px');
+  });
+});

--- a/projects/swimlane/ngx-datatable/src/lib/utils/column.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/utils/column.ts
@@ -69,7 +69,7 @@ export const gridColumnTemplate = (cols: PinnedColumns[]): string => {
 };
 
 const gridColumnTrack = (column: TableColumnInternal): string => {
-  const width = `${column.width()}px`;
+  const width = `${Math.max(0, column.width())}px`;
   const min = column.minWidth ? `${column.minWidth}px` : undefined;
   const max = column.maxWidth ? `${column.maxWidth}px` : undefined;
   if (min && max) {

--- a/projects/swimlane/ngx-datatable/src/lib/utils/math.spec.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/utils/math.spec.ts
@@ -183,6 +183,51 @@ describe('Math function', () => {
         adjustColumnWidths(cols, 500);
         expect(cols.map(c => c.width())).toEqual([100, 200, 200]);
       });
+
+      it('should never produce negative widths for flexGrow 0 + canAutoResize true', () => {
+        const cols = toInternalColumn([
+          { prop: 'expand', width: 58, canAutoResize: false },
+          { prop: 'status', flexGrow: 1.5, minWidth: 160, canAutoResize: true },
+          { prop: 'name', flexGrow: 1, canAutoResize: true },
+          { prop: 'duration', width: 100, flexGrow: 0, canAutoResize: true }
+        ]);
+
+        adjustColumnWidths(cols, 500);
+
+        for (const col of cols) {
+          expect(col.width()).toBeGreaterThanOrEqual(0);
+        }
+      });
+
+      it('should not produce negative widths when minWidths exceed available space', () => {
+        const cols = toInternalColumn([
+          { prop: 'expand', width: 58, canAutoResize: false },
+          { prop: 'status', flexGrow: 1.5, minWidth: 160, canAutoResize: true },
+          { prop: 'name', flexGrow: 1, canAutoResize: true },
+          { prop: 'duration', width: 100, flexGrow: 0, canAutoResize: true }
+        ]);
+
+        adjustColumnWidths(cols, 200);
+
+        for (const col of cols) {
+          expect(col.width()).toBeGreaterThanOrEqual(0);
+        }
+      });
+
+      it('should distribute remaining width across flexGrow columns with locked siblings', () => {
+        const cols = toInternalColumn([
+          { prop: 'locked', width: 100, canAutoResize: false },
+          { prop: 'flexA', width: 50, flexGrow: 1, canAutoResize: true },
+          { prop: 'flexB', width: 50, flexGrow: 3, canAutoResize: true }
+        ]);
+
+        adjustColumnWidths(cols, 500);
+
+        expect(cols[0].width()).toBe(100);
+        expect(cols[1].width()).toBeCloseTo(100, 5);
+        expect(cols[2].width()).toBeCloseTo(300, 5);
+        expect(cols.reduce((sum, c) => sum + c.width(), 0)).toBeCloseTo(500, 5);
+      });
     });
   });
 });

--- a/projects/swimlane/ngx-datatable/src/lib/utils/math.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/utils/math.ts
@@ -66,7 +66,8 @@ const scaleColumns = (colsByGroup: TableColumnGroup, maxWidth: number, totalFlex
           column.width.set(column.minWidth);
           hasMinWidth[column.prop] = true;
         } else {
-          column.width.set(newWidth);
+          // Never allow negative tracks (aligns with forceFillColumnWidths).
+          column.width.set(Math.max(0, newWidth));
         }
       }
     }
@@ -80,14 +81,25 @@ const scaleColumns = (colsByGroup: TableColumnGroup, maxWidth: number, totalFlex
     return;
   }
 
-  // adjust the first column that can be auto-resized respecting the min/max widths
-  for (const col of columns.filter(c => c.canAutoResize).sort((a, b) => a.width() - b.width())) {
+  // Prefer flexGrow > 0 columns that can absorb delta; skip zero-width /
+  // flexGrow-0 columns so leftover float/minWidth noise cannot go negative.
+  for (const col of columns
+    .filter(c => c.canAutoResize && (c.flexGrow ?? 0) > 0)
+    .sort((a, b) => a.width() - b.width())) {
     if (
       (delta > 0 && (!col.maxWidth || col.width() + delta <= col.maxWidth)) ||
-      (delta < 0 && (!col.minWidth || col.width() + delta >= col.minWidth))
+      (delta < 0 &&
+        col.width() + delta >= 0 &&
+        (!col.minWidth || col.width() + delta >= col.minWidth))
     ) {
-      col.width.update(value => value + delta);
+      col.width.update(value => Math.max(0, value + delta));
       break;
+    }
+  }
+
+  for (const col of columns) {
+    if (col.width() < 0) {
+      col.width.set(0);
     }
   }
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

In flex mode, `scaleColumns` can leave a column width slightly (float noise) or largely (minWidth starvation) negative. In v25+, those widths are written into CSS `grid-template-columns` / `--ngx-datatable-grid-template-columns`. A negative track invalidates the whole declaration, so the browser falls back to a single column: headers stack and body cells overlap.

**What is the new behavior?**

- `scaleColumns` clamps widths with `Math.max(0, …)` (same guard as `forceFillColumnWidths`)
- Leftover `delta` is only applied to `flexGrow > 0` columns that can absorb it without going negative
- `gridColumnTrack` also clamps so negative values never reach CSS even if math regresses

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Minimal fix only—no flexGrow-0 semantic change. Unit tests cover float/minWidth starvation cases, locked+flex distribution, and non-negative grid track strings.

Made with [Cursor](https://cursor.com)