### PR TITLE
(release): 25.1.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 25.1.0
+
 ### Features
 
 - Enhancement: Added support for Angular 22

--- a/projects/ngx-datatable/package.json
+++ b/projects/ngx-datatable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-datatable",
-  "version": "24.0.0",
+  "version": "25.1.0",
   "description": "ngx-datatable is an Angular table grid component for presenting large and complex data.",
   "publishConfig": {
     "access": "public"

--- a/projects/swimlane/ngx-datatable/package.json
+++ b/projects/swimlane/ngx-datatable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-datatable",
-  "version": "26.0.0-beta.0",
+  "version": "25.1.0",
   "description": "ngx-datatable is an Angular table grid component for presenting large and complex data.",
   "peerDependencies": {
     "@angular/common": "20.x || 21.x || 22.x",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Release version bump for 25.1.0

**What is the current behavior?** (You can also link to an open issue here)

Package version is still pre-release (`26.0.0-beta.0` / `24.0.0` in the duplicate package metadata), and CHANGELOG entries for Angular 22, CSS-grid layout, and related fixes remain under HEAD.

**What is the new behavior?**

Bumps `@swimlane/ngx-datatable` to **25.1.0** and promotes the unreleased CHANGELOG section to `## 25.1.0` (leaving an empty HEAD for future work).

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications:

This release ships previously landed breaking changes already on master:
- Removed support for Angular 19 and earlier (requires Angular 20+)
- Removed deprecated `sort` output → use `(sortsChange)` / `[(sorts)]`
- Removed deprecated `select` output → use `(selectedChange)` / `[(selected)]`
- Removed visibility observer → recalculation via `ResizeObserver` / layout

**Other information**:

Draft release PR. After merge (or per repo release flow): tag `25.1.0`, push tags, then `yarn publish`.


Made with [Cursor](https://cursor.com)